### PR TITLE
[A2UI] Bump `glchat-a2ui-react-renderer` to `0.2.7`

### DIFF
--- a/gen-ai/examples/a2ui/a2ui-nextjs/package-lock.json
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agent-a2ui-compliant",
       "version": "0.1.0",
       "dependencies": {
-        "glchat-a2ui-react-renderer": "^0.2.6",
+        "glchat-a2ui-react-renderer": "^0.2.7",
         "lucide-react": "^0.575.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -3989,10 +3989,11 @@
       }
     },
     "node_modules/glchat-a2ui-react-renderer": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.2.6.tgz",
-      "integrity": "sha512-de06VKA2gQtSr//JnV/aRG/KhgOy6PUKcDW9D8nz91ns3rdk9M4FCX9vj7DUuPhoEnRWGb9fcJfRYfqrXHm3Bg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.2.7.tgz",
+      "integrity": "sha512-05i74SQbzDPAk/6Ephf6DPz6iP61xnyJEd4hGUji4RBMag4xL8EfNJtrEzQiQfw9MEGZPIHk54dtHfs54ywDcw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@a2ui/react": "^0.10.0",
         "@a2ui/web_core": "^0.10.0",
@@ -10624,9 +10625,9 @@
       }
     },
     "glchat-a2ui-react-renderer": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.2.6.tgz",
-      "integrity": "sha512-de06VKA2gQtSr//JnV/aRG/KhgOy6PUKcDW9D8nz91ns3rdk9M4FCX9vj7DUuPhoEnRWGb9fcJfRYfqrXHm3Bg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.2.7.tgz",
+      "integrity": "sha512-05i74SQbzDPAk/6Ephf6DPz6iP61xnyJEd4hGUji4RBMag4xL8EfNJtrEzQiQfw9MEGZPIHk54dtHfs54ywDcw==",
       "requires": {
         "@a2ui/react": "^0.10.0",
         "@a2ui/web_core": "^0.10.0",

--- a/gen-ai/examples/a2ui/a2ui-nextjs/package.json
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/package.json
@@ -11,7 +11,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "glchat-a2ui-react-renderer": "^0.2.6",
+    "glchat-a2ui-react-renderer": "^0.2.7",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/app/layout.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/app/layout.tsx
@@ -13,7 +13,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="bg-white antialiased">{children}</body>
+      <head>
+        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
+        <link
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="bg-white antialiased">{children}ii</body>
     </html>
   );
 }

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/MessageInput.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/MessageInput.tsx
@@ -57,7 +57,7 @@ export default function MessageInput({ onSendMessage, isLoading }: MessageInputP
           onKeyDown={handleKeyDown}
           placeholder="Send simple message like 'show text'"
           rows={1}
-          className="w-full resize-none rounded-xl border border-gray-300 bg-gray-100 px-4 py-3 pr-12 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          className="w-full resize-none rounded-xl border border-gray-300 bg-gray-100 px-4 py-3 pr-12 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-primary focus:outline-none"
         />
         <SendButton disabled={!input.trim() || isLoading} onClick={handleSend} />
       </div>

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/components.json
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/components.json
@@ -1,0 +1,1346 @@
+[
+  {
+    "surfaceUpdate": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": { "Card": { "child": "comp-content" } }
+        },
+        {
+          "id": "comp-content",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": [
+                  "comp-header",
+                  "comp-caption",
+                  "div-0",
+                  "label-01",
+                  "text-showcase",
+                  "div-01",
+                  "label-02",
+                  "image-showcase",
+                  "div-02",
+                  "label-03",
+                  "icon-showcase",
+                  "div-03",
+                  "label-04",
+                  "catalog-video",
+                  "div-04",
+                  "label-05",
+                  "catalog-audio",
+                  "div-05",
+                  "label-06",
+                  "demo-row",
+                  "div-06",
+                  "label-07",
+                  "demo-column",
+                  "div-07",
+                  "label-08",
+                  "catalog-list",
+                  "div-08",
+                  "label-09",
+                  "demo-card",
+                  "div-09",
+                  "label-10",
+                  "catalog-tabs",
+                  "div-10",
+                  "label-11",
+                  "divider-h",
+                  "divider-v-row",
+                  "div-11",
+                  "label-12",
+                  "catalog-modal",
+                  "div-12",
+                  "label-13",
+                  "actions-primary-row",
+                  "div-13",
+                  "label-14",
+                  "destructive-btn",
+                  "div-14",
+                  "label-15",
+                  "catalog-button-as-link",
+                  "div-15",
+                  "label-16",
+                  "catalog-checkbox",
+                  "div-16",
+                  "label-17",
+                  "textfield-showcase",
+                  "div-17",
+                  "label-18",
+                  "datetime-showcase",
+                  "div-18",
+                  "label-19",
+                  "mc-showcase",
+                  "div-19",
+                  "label-20",
+                  "catalog-slider",
+                  "div-20",
+                  "label-21",
+                  "taginput-caption",
+                  "catalog-taginput",
+                  "div-21",
+                  "label-22",
+                  "timeout-caption",
+                  "catalog-timeout",
+                  "div-bottom",
+                  "btn-row"
+                ]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+
+        {
+          "id": "comp-header",
+          "component": {
+            "Text": {
+              "text": { "literalString": "GLChat Standard Catalog" },
+              "usageHint": "h1"
+            }
+          }
+        },
+        {
+          "id": "comp-caption",
+          "component": {
+            "Text": {
+              "text": {
+                "literalString": "All 22 components from glchat_standard_catalog_definition.json — typography, layout, media, overlays, actions, and form controls."
+              },
+              "usageHint": "caption"
+            }
+          }
+        },
+        { "id": "div-0", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-01",
+          "component": {
+            "Text": {
+              "text": { "literalString": "01 · Text" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "text-showcase",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": [
+                  "text-h1",
+                  "text-h2",
+                  "text-h3",
+                  "text-h4",
+                  "text-h5",
+                  "text-body",
+                  "text-caption"
+                ]
+              },
+              "distribution": "start",
+              "alignment": "start"
+            }
+          }
+        },
+        {
+          "id": "text-h1",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Heading 1 — usageHint: h1" },
+              "usageHint": "h1"
+            }
+          }
+        },
+        {
+          "id": "text-h2",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Heading 2 — usageHint: h2" },
+              "usageHint": "h2"
+            }
+          }
+        },
+        {
+          "id": "text-h3",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Heading 3 — usageHint: h3" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "text-h4",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Heading 4 — usageHint: h4" },
+              "usageHint": "h4"
+            }
+          }
+        },
+        {
+          "id": "text-h5",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Heading 5 — usageHint: h5" },
+              "usageHint": "h5"
+            }
+          }
+        },
+        {
+          "id": "text-body",
+          "component": {
+            "Text": {
+              "text": {
+                "literalString": "Body text supports simple **markdown** formatting for emphasis."
+              },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "text-caption",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Caption — smaller supporting text" },
+              "usageHint": "caption"
+            }
+          }
+        },
+        { "id": "div-01", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-02",
+          "component": {
+            "Text": {
+              "text": { "literalString": "02 · Image" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "image-showcase",
+          "component": {
+            "Row": {
+              "children": {
+                "explicitList": ["img-icon", "img-avatar", "img-feature"]
+              },
+              "distribution": "start",
+              "alignment": "center"
+            }
+          }
+        },
+        {
+          "id": "img-icon",
+          "component": {
+            "Image": {
+              "url": { "literalString": "https://picsum.photos/seed/icon/48/48" },
+              "fit": "cover",
+              "usageHint": "icon"
+            }
+          }
+        },
+        {
+          "id": "img-avatar",
+          "component": {
+            "Image": {
+              "url": { "literalString": "https://picsum.photos/seed/avatar/80/80" },
+              "fit": "cover",
+              "usageHint": "avatar"
+            }
+          }
+        },
+        {
+          "id": "img-feature",
+          "component": {
+            "Image": {
+              "url": { "path": "/comp/imageUrl" },
+              "fit": "cover",
+              "usageHint": "mediumFeature"
+            }
+          }
+        },
+        { "id": "div-02", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-03",
+          "component": {
+            "Text": {
+              "text": { "literalString": "03 · Icon" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "icon-showcase",
+          "component": {
+            "Row": {
+              "children": {
+                "explicitList": [
+                  "icon-check",
+                  "icon-error",
+                  "icon-warning",
+                  "icon-star",
+                  "icon-settings",
+                  "icon-home",
+                  "icon-search"
+                ]
+              },
+              "distribution": "start",
+              "alignment": "center"
+            }
+          }
+        },
+        {
+          "id": "icon-check",
+          "component": { "Icon": { "name": { "literalString": "check" } } }
+        },
+        {
+          "id": "icon-error",
+          "component": { "Icon": { "name": { "literalString": "error" } } }
+        },
+        {
+          "id": "icon-warning",
+          "component": { "Icon": { "name": { "literalString": "warning" } } }
+        },
+        {
+          "id": "icon-star",
+          "component": { "Icon": { "name": { "literalString": "star" } } }
+        },
+        {
+          "id": "icon-settings",
+          "component": { "Icon": { "name": { "literalString": "settings" } } }
+        },
+        {
+          "id": "icon-home",
+          "component": { "Icon": { "name": { "literalString": "home" } } }
+        },
+        {
+          "id": "icon-search",
+          "component": { "Icon": { "name": { "literalString": "search" } } }
+        },
+        { "id": "div-03", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-04",
+          "component": {
+            "Text": {
+              "text": { "literalString": "04 · Video" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-video",
+          "component": {
+            "Video": {
+              "url": { "literalString": "https://www.w3schools.com/html/mov_bbb.mp4" }
+            }
+          }
+        },
+        { "id": "div-04", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-05",
+          "component": {
+            "Text": {
+              "text": { "literalString": "05 · AudioPlayer" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-audio",
+          "component": {
+            "AudioPlayer": {
+              "url": { "literalString": "https://www.w3schools.com/html/horse.mp3" },
+              "description": { "literalString": "Sample audio clip" }
+            }
+          }
+        },
+        { "id": "div-05", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-06",
+          "component": {
+            "Text": {
+              "text": { "literalString": "06 · Row" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "demo-row",
+          "component": {
+            "Row": {
+              "children": {
+                "explicitList": ["row-left", "row-center", "row-right"]
+              },
+              "distribution": "spaceBetween",
+              "alignment": "center"
+            }
+          }
+        },
+        {
+          "id": "row-left",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Left" },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "row-center",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Center" },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "row-right",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Right" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-06", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-07",
+          "component": {
+            "Text": {
+              "text": { "literalString": "07 · Column" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "demo-column",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": ["col-item-1", "col-item-2", "col-item-3"]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+        {
+          "id": "col-item-1",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Stacked item one" },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "col-item-2",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Stacked item two" },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "col-item-3",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Stacked item three" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-07", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-08",
+          "component": {
+            "Text": {
+              "text": { "literalString": "08 · List" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-list",
+          "component": {
+            "List": {
+              "children": {
+                "template": {
+                  "componentId": "list-item-template",
+                  "dataBinding": "/comp/listItems"
+                }
+              },
+              "direction": "vertical",
+              "alignment": "start"
+            }
+          }
+        },
+        {
+          "id": "list-item-template",
+          "component": {
+            "Text": {
+              "text": { "path": "label" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-08", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-09",
+          "component": {
+            "Text": {
+              "text": { "literalString": "09 · Card" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "demo-card",
+          "component": {
+            "Card": { "child": "demo-card-inner" }
+          }
+        },
+        {
+          "id": "demo-card-inner",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": ["demo-card-title", "demo-card-body"]
+              },
+              "distribution": "start",
+              "alignment": "start"
+            }
+          }
+        },
+        {
+          "id": "demo-card-title",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Card title" },
+              "usageHint": "h4"
+            }
+          }
+        },
+        {
+          "id": "demo-card-body",
+          "component": {
+            "Text": {
+              "text": {
+                "literalString": "A Card wraps a single child — often a Column or Row for grouped content."
+              },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-09", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-10",
+          "component": {
+            "Text": {
+              "text": { "literalString": "10 · Tabs" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-tabs",
+          "component": {
+            "Tabs": {
+              "tabItems": [
+                { "title": { "literalString": "Overview" }, "child": "tab-overview" },
+                { "title": { "literalString": "Details" }, "child": "tab-details" },
+                { "title": { "literalString": "Settings" }, "child": "tab-settings" }
+              ]
+            }
+          }
+        },
+        {
+          "id": "tab-overview",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Overview panel — summary information at a glance." },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "tab-details",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Details panel — extended metadata and specifications." },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "tab-settings",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Settings panel — configuration options." },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-10", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-11",
+          "component": {
+            "Text": {
+              "text": { "literalString": "11 · Divider" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        { "id": "divider-h", "component": { "Divider": { "axis": "horizontal" } } },
+        {
+          "id": "divider-v-row",
+          "component": {
+            "Row": {
+              "children": {
+                "explicitList": ["divider-v-left", "divider-v", "divider-v-right"]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+        {
+          "id": "divider-v-left",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Left of vertical divider" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "divider-v", "component": { "Divider": { "axis": "vertical" } } },
+        {
+          "id": "divider-v-right",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Right of vertical divider" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-11", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-12",
+          "component": {
+            "Text": {
+              "text": { "literalString": "12 · Modal" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-modal",
+          "component": {
+            "Modal": {
+              "entryPointChild": "modal-open-btn",
+              "contentChild": "modal-body-col"
+            }
+          }
+        },
+        {
+          "id": "modal-open-btn",
+          "component": {
+            "Button": {
+              "child": "modal-open-text",
+              "action": { "name": "modal_open", "context": [] },
+              "primary": false
+            }
+          }
+        },
+        {
+          "id": "modal-open-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Open Modal" },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "modal-body-col",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": ["modal-title", "modal-body-text", "modal-close-btn"]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+        {
+          "id": "modal-title",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Modal Title" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "modal-body-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Content rendered inside the modal overlay." },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "modal-close-btn",
+          "component": {
+            "Button": {
+              "child": "modal-close-text",
+              "action": { "name": "modal_close", "context": [] },
+              "primary": true
+            }
+          }
+        },
+        {
+          "id": "modal-close-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Close" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-12", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-13",
+          "component": {
+            "Text": {
+              "text": { "literalString": "13 · Button" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "actions-primary-row",
+          "component": {
+            "Row": {
+              "children": {
+                "explicitList": ["btn-primary", "btn-secondary"]
+              },
+              "distribution": "start",
+              "alignment": "center"
+            }
+          }
+        },
+        {
+          "id": "btn-primary",
+          "component": {
+            "Button": {
+              "child": "btn-primary-text",
+              "action": { "name": "primary_action", "context": [] },
+              "primary": true
+            }
+          }
+        },
+        {
+          "id": "btn-primary-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Primary" },
+              "usageHint": "body"
+            }
+          }
+        },
+        {
+          "id": "btn-secondary",
+          "component": {
+            "Button": {
+              "child": "btn-secondary-text",
+              "action": { "name": "secondary_action", "context": [] },
+              "primary": false
+            }
+          }
+        },
+        {
+          "id": "btn-secondary-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Secondary" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-13", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-14",
+          "component": {
+            "Text": {
+              "text": { "literalString": "14 · DestructiveButton" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "destructive-btn",
+          "component": {
+            "DestructiveButton": {
+              "child": "destructive-btn-text",
+              "action": { "name": "delete_item", "context": [] }
+            }
+          }
+        },
+        {
+          "id": "destructive-btn-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Delete" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-14", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-15",
+          "component": {
+            "Text": {
+              "text": { "literalString": "15 · ButtonAsLink" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-button-as-link",
+          "component": {
+            "ButtonAsLink": {
+              "child": "catalog-button-as-link-text",
+              "href": { "path": "/comp/downloadUrl" },
+              "target": { "literalString": "_blank" }
+            }
+          }
+        },
+        {
+          "id": "catalog-button-as-link-text",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Download sample file ↗" },
+              "usageHint": "body"
+            }
+          }
+        },
+        { "id": "div-15", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-16",
+          "component": {
+            "Text": {
+              "text": { "literalString": "16 · CheckBox" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-checkbox",
+          "component": {
+            "CheckBox": {
+              "label": { "path": "/comp/checkbox/label" },
+              "value": { "path": "/comp/checkbox/value" }
+            }
+          }
+        },
+        { "id": "div-16", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-17",
+          "component": {
+            "Text": {
+              "text": { "literalString": "17 · TextField" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "textfield-showcase",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": [
+                  "tf-short",
+                  "tf-long",
+                  "tf-number",
+                  "tf-date",
+                  "tf-obscured"
+                ]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+        {
+          "id": "tf-short",
+          "component": {
+            "TextField": {
+              "label": { "literalString": "Short text" },
+              "text": { "path": "/comp/text" },
+              "textFieldType": "shortText"
+            }
+          }
+        },
+        {
+          "id": "tf-long",
+          "component": {
+            "TextField": {
+              "label": { "literalString": "Long text" },
+              "text": { "path": "/comp/bio" },
+              "textFieldType": "longText"
+            }
+          }
+        },
+        {
+          "id": "tf-number",
+          "component": {
+            "TextField": {
+              "label": { "literalString": "Number" },
+              "text": { "path": "/comp/age" },
+              "textFieldType": "number"
+            }
+          }
+        },
+        {
+          "id": "tf-date",
+          "component": {
+            "TextField": {
+              "label": { "literalString": "Date" },
+              "text": { "path": "/comp/dob" },
+              "textFieldType": "date"
+            }
+          }
+        },
+        {
+          "id": "tf-obscured",
+          "component": {
+            "TextField": {
+              "label": { "literalString": "Password (obscured)" },
+              "text": { "path": "/comp/password" },
+              "textFieldType": "obscured"
+            }
+          }
+        },
+        { "id": "div-17", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-18",
+          "component": {
+            "Text": {
+              "text": { "literalString": "18 · DateTimeInput" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "datetime-showcase",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": ["dt-datetime", "dt-date-only", "dt-time-only"]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+        {
+          "id": "dt-datetime",
+          "component": {
+            "DateTimeInput": {
+              "value": { "path": "/comp/datetime" },
+              "enableDate": true,
+              "enableTime": true
+            }
+          }
+        },
+        {
+          "id": "dt-date-only",
+          "component": {
+            "DateTimeInput": {
+              "value": { "path": "/comp/dateOnly" },
+              "enableDate": true,
+              "enableTime": false
+            }
+          }
+        },
+        {
+          "id": "dt-time-only",
+          "component": {
+            "DateTimeInput": {
+              "value": { "path": "/comp/timeOnly" },
+              "enableDate": false,
+              "enableTime": true
+            }
+          }
+        },
+        { "id": "div-18", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-19",
+          "component": {
+            "Text": {
+              "text": { "literalString": "19 · MultipleChoice" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "mc-showcase",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": [
+                  "mc-single-chip-label",
+                  "mc-single-chip",
+                  "mc-single-checkbox-label",
+                  "mc-single-checkbox",
+                  "mc-multi-chip-label",
+                  "mc-multi-chip",
+                  "mc-multi-checkbox-label",
+                  "mc-multi-checkbox"
+                ]
+              },
+              "distribution": "start",
+              "alignment": "stretch"
+            }
+          }
+        },
+        {
+          "id": "mc-single-chip-label",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Single select · chips" },
+              "usageHint": "caption"
+            }
+          }
+        },
+        {
+          "id": "mc-single-chip",
+          "component": {
+            "MultipleChoice": {
+              "selections": { "path": "/comp/mcSingleChip" },
+              "type": "chips",
+              "maxAllowedSelections": 1,
+              "options": [
+                { "value": "en", "label": { "literalString": "English" } },
+                { "value": "id", "label": { "literalString": "Indonesian" } },
+                { "value": "ja", "label": { "literalString": "Japanese" } }
+              ]
+            }
+          }
+        },
+        {
+          "id": "mc-single-checkbox-label",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Single select · checkbox" },
+              "usageHint": "caption"
+            }
+          }
+        },
+        {
+          "id": "mc-single-checkbox",
+          "component": {
+            "MultipleChoice": {
+              "selections": { "path": "/comp/mcSingleCheckbox" },
+              "type": "checkbox",
+              "maxAllowedSelections": 1,
+              "options": [
+                { "value": "free", "label": { "literalString": "Free" } },
+                { "value": "pro", "label": { "literalString": "Pro" } },
+                { "value": "enterprise", "label": { "literalString": "Enterprise" } }
+              ]
+            }
+          }
+        },
+        {
+          "id": "mc-multi-chip-label",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Multi select · chips" },
+              "usageHint": "caption"
+            }
+          }
+        },
+        {
+          "id": "mc-multi-chip",
+          "component": {
+            "MultipleChoice": {
+              "selections": { "path": "/comp/mcMultiChip" },
+              "type": "chips",
+              "maxAllowedSelections": 4,
+              "options": [
+                { "value": "mon", "label": { "literalString": "Mon" } },
+                { "value": "tue", "label": { "literalString": "Tue" } },
+                { "value": "wed", "label": { "literalString": "Wed" } },
+                { "value": "thu", "label": { "literalString": "Thu" } },
+                { "value": "fri", "label": { "literalString": "Fri" } }
+              ]
+            }
+          }
+        },
+        {
+          "id": "mc-multi-checkbox-label",
+          "component": {
+            "Text": {
+              "text": { "literalString": "Multi select · checkbox" },
+              "usageHint": "caption"
+            }
+          }
+        },
+        {
+          "id": "mc-multi-checkbox",
+          "component": {
+            "MultipleChoice": {
+              "selections": { "path": "/comp/mcMultiCheckbox" },
+              "type": "checkbox",
+              "maxAllowedSelections": 3,
+              "options": [
+                { "value": "design", "label": { "literalString": "Design" } },
+                { "value": "frontend", "label": { "literalString": "Frontend" } },
+                { "value": "backend", "label": { "literalString": "Backend" } },
+                { "value": "devops", "label": { "literalString": "DevOps" } }
+              ]
+            }
+          }
+        },
+        { "id": "div-19", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-20",
+          "component": {
+            "Text": {
+              "text": { "literalString": "20 · Slider" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "catalog-slider",
+          "component": {
+            "Slider": {
+              "value": { "path": "/comp/volume" },
+              "minValue": 0,
+              "maxValue": 100
+            }
+          }
+        },
+        { "id": "div-20", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-21",
+          "component": {
+            "Text": {
+              "text": { "literalString": "21 · TagInput" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "taginput-caption",
+          "component": {
+            "Text": {
+              "text": {
+                "literalString": "Type a tag and press Enter. Email validation via validationRegexp."
+              },
+              "usageHint": "caption"
+            }
+          }
+        },
+        {
+          "id": "catalog-taginput",
+          "component": {
+            "TagInput": {
+              "label": { "literalString": "Skills" },
+              "values": { "path": "/comp/tags" },
+              "placeholder": { "literalString": "e.g. TypeScript" },
+              "validationRegexp": "^[a-zA-Z0-9+\\-\\. ]{2,32}$",
+              "validationErrorMessage": {
+                "literalString": "Tags must be 2–32 characters (letters, numbers, +, -, ., space)."
+              }
+            }
+          }
+        },
+        { "id": "div-21", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "label-22",
+          "component": {
+            "Text": {
+              "text": { "literalString": "22 · Timeout" },
+              "usageHint": "h3"
+            }
+          }
+        },
+        {
+          "id": "timeout-caption",
+          "component": {
+            "Text": {
+              "text": {
+                "literalString": "Countdown to targetTimeUtc (ISO 8601). Updates live until the target is reached."
+              },
+              "usageHint": "caption"
+            }
+          }
+        },
+        {
+          "id": "catalog-timeout",
+          "component": {
+            "Timeout": {
+              "targetTimeUtc": { "path": "/comp/timeoutExpires" }
+            }
+          }
+        },
+        { "id": "div-bottom", "component": { "Divider": { "axis": "horizontal" } } },
+
+        {
+          "id": "btn-row",
+          "component": {
+            "Row": {
+              "children": { "explicitList": ["submit-btn"] },
+              "distribution": "end",
+              "alignment": "center"
+            }
+          }
+        },
+        {
+          "id": "submit-btn",
+          "component": {
+            "Button": {
+              "child": "submit-text",
+              "action": {
+                "name": "catalog_submit",
+                "context": [
+                  { "key": "text", "value": { "path": "/comp/text" } },
+                  { "key": "bio", "value": { "path": "/comp/bio" } },
+                  { "key": "age", "value": { "path": "/comp/age" } },
+                  { "key": "dob", "value": { "path": "/comp/dob" } },
+                  { "key": "password", "value": { "path": "/comp/password" } },
+                  { "key": "checkbox", "value": { "path": "/comp/checkbox/value" } },
+                  { "key": "datetime", "value": { "path": "/comp/datetime" } },
+                  { "key": "mcSingleChip", "value": { "path": "/comp/mcSingleChip" } },
+                  { "key": "mcSingleCheckbox", "value": { "path": "/comp/mcSingleCheckbox" } },
+                  { "key": "mcMultiChip", "value": { "path": "/comp/mcMultiChip" } },
+                  { "key": "mcMultiCheckbox", "value": { "path": "/comp/mcMultiCheckbox" } },
+                  { "key": "volume", "value": { "path": "/comp/volume" } },
+                  { "key": "tags", "value": { "path": "/comp/tags" } }
+                ]
+              },
+              "primary": true
+            }
+          }
+        },
+        {
+          "id": "submit-text",
+          "component": {
+            "Text": { "text": { "literalString": "Submit" }, "usageHint": "body" }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "dataModelUpdate": {
+      "surfaceId": "main",
+      "contents": [
+        {
+          "key": "comp",
+          "valueMap": [
+            { "key": "text", "valueString": "Hello A2UI" },
+            { "key": "bio", "valueString": "A short bio for the longText field." },
+            { "key": "age", "valueString": "28" },
+            { "key": "dob", "valueString": "1998-03-15" },
+            { "key": "password", "valueString": "" },
+            { "key": "datetime", "valueString": "2026-06-18T14:30:00.000Z" },
+            { "key": "dateOnly", "valueString": "2026-06-18" },
+            { "key": "timeOnly", "valueString": "2026-06-18T09:00:00.000Z" },
+            { "key": "imageUrl", "valueString": "https://picsum.photos/seed/catalog/640/360" },
+            { "key": "volume", "valueNumber": 50 },
+            { "key": "timeoutExpires", "valueString": "2026-12-31T23:59:59.000Z" },
+            {
+              "key": "downloadUrl",
+              "valueString": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+            },
+            {
+              "key": "checkbox",
+              "valueMap": [
+                { "key": "value", "valueBoolean": true },
+                { "key": "label", "valueString": "Enable email notifications" }
+              ]
+            },
+            {
+              "key": "mcSingleChip",
+              "valueMap": [{ "key": "0", "valueString": "en" }]
+            },
+            {
+              "key": "mcSingleCheckbox",
+              "valueMap": [{ "key": "0", "valueString": "pro" }]
+            },
+            {
+              "key": "mcMultiChip",
+              "valueMap": [
+                { "key": "0", "valueString": "mon" },
+                { "key": "1", "valueString": "wed" },
+                { "key": "2", "valueString": "fri" }
+              ]
+            },
+            {
+              "key": "mcMultiCheckbox",
+              "valueMap": [
+                { "key": "0", "valueString": "design" },
+                { "key": "1", "valueString": "frontend" }
+              ]
+            },
+            {
+              "key": "tags",
+              "valueMap": [
+                { "key": "0", "valueString": "TypeScript" },
+                { "key": "1", "valueString": "A2UI" }
+              ]
+            },
+            {
+              "key": "listItems",
+              "valueMap": [
+                { "key": "0", "valueMap": [{ "key": "label", "valueString": "Dynamic list item 1" }] },
+                { "key": "1", "valueMap": [{ "key": "label", "valueString": "Dynamic list item 2" }] },
+                { "key": "2", "valueMap": [{ "key": "label", "valueString": "Dynamic list item 3" }] }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "beginRendering": {
+      "surfaceId": "main",
+      "root": "root",
+      "catalogId": "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json"
+    }
+  }
+]

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/components.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/components.ts
@@ -1,0 +1,3 @@
+import componentsSampleData from "./components.json";
+
+export const componentsSample = componentsSampleData;

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/greetings.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/greetings.ts
@@ -135,6 +135,12 @@ export const helloSample = [
             { key: "command", valueString: "• 'delete-surface' - Surface deletion (temporary)" },
           ],
         },
+        {
+          key: "11",
+          valueMap: [
+            { key: "command", valueString: "• 'components' - Full GLChat catalog (all 22 components)" },
+          ],
+        },
       ],
     },
   },

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/hitl.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/hitl.ts
@@ -167,7 +167,7 @@ export const hitlSample = [
         {
           id: "reject-btn",
           component: {
-            Button: {
+            DestructiveButton: {
               child: "reject-text",
               action: {
                 name: "hitl_decision",
@@ -176,8 +176,6 @@ export const hitlSample = [
                   { key: "requestId", value: { path: "/hitl/requestId" } },
                 ],
               },
-              primary: false,
-              destructive: true,
             },
           },
         },

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/types/chat.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/types/chat.ts
@@ -49,4 +49,5 @@ export type SampleType =
   | "product"
   | "layout"
   | "delete-surface"
+  | "components"
   | "hello";

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/utils/a2uiMockMessage.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/utils/a2uiMockMessage.ts
@@ -7,6 +7,7 @@ import { hitlSample } from "@/sampleAgentData/hitl";
 import { layoutSample } from "@/sampleAgentData/layout";
 import { productSample } from "@/sampleAgentData/product";
 import { profileSample } from "@/sampleAgentData/profile";
+import { componentsSample } from "@/sampleAgentData/components";
 import { settingsSample } from "@/sampleAgentData/setting";
 import { typographySample } from "@/sampleAgentData/typography";
 import { SampleType } from "@/types/chat";
@@ -30,6 +31,7 @@ const samples: Record<SampleType, object[]> = {
   product: productSample,
   layout: layoutSample,
   "delete-surface": deleteSurfaceSample,
+  components: componentsSample,
   hello: helloSample,
 };
 
@@ -45,6 +47,7 @@ export function detectSampleType(input: string): SampleType {
   if (lower.includes("product") || lower.includes("card")) return "product";
   if (lower.includes("layout") || lower.includes("grid")) return "layout";
   if (lower.includes("delete") || lower.includes("remove")) return "delete-surface";
+  if (lower.includes("components") || lower.includes("component")) return "components";
   return "hello";
 }
 


### PR DESCRIPTION
- Bump `glchat-a2ui-react-renderer` to `0.2.7`
- Introduce new command to display all supported components

<img width="466" height="625" alt="image" src="https://github.com/user-attachments/assets/1597fd2f-b4db-4f97-9868-12608d4b876c" />
<img width="466" height="891" alt="image" src="https://github.com/user-attachments/assets/374cdfe9-6233-41e5-b9f2-2850a3c6758c" />
<img width="466" height="811" alt="image" src="https://github.com/user-attachments/assets/199649a2-a005-4736-92a0-b9e72e5f34ed" />
<img width="466" height="835" alt="image" src="https://github.com/user-attachments/assets/948176ee-4d66-438d-a341-f69c5e86e59b" />
