### PR TITLE
refactor(evaluations): promote evaluate_suites() API across all tutorials

### DIFF
--- a/gen-ai/tutorials/evaluations/agent_evaluation_tutorial/main_with_evaluate_helper.py
+++ b/gen-ai/tutorials/evaluations/agent_evaluation_tutorial/main_with_evaluate_helper.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 
-from gllm_evals import LLMTestCase
-from gllm_evals.dataset.simple_agent_tool_call_dataset import load_simple_agent_tool_call_dataset
-from gllm_evals.evaluate import evaluate
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
+from gllm_evals.dataset.simple_agent_tool_call_dataset import (
+    load_simple_agent_tool_call_dataset,
+)
 from gllm_evals.evaluator.agent_evaluator import AgentEvaluator
 
 
@@ -13,13 +14,15 @@ async def main() -> None:
     Loads the dataset, formats agent responses into LLMTestCase objects,
     and runs batch evaluation using the evaluate() helper with AgentEvaluator.
     """
-    rows = load_simple_agent_tool_call_dataset('./dataset_examples')
+    rows = load_simple_agent_tool_call_dataset("./dataset_examples")
 
     data = [
         LLMTestCase(
             input=row.get("query", row.get("input", "")),
             actual_output=row.get("generated_response", row.get("actual_output", "")),
-            expected_output=row.get("expected_response", row.get("expected_output", "")),
+            expected_output=row.get(
+                "expected_response", row.get("expected_output", "")
+            ),
             agent_trajectory=row.get("agent_trajectory", []),
             expected_agent_trajectory=row.get("expected_agent_trajectory", []),
             tools_called=row.get("tools_called", []),
@@ -28,9 +31,12 @@ async def main() -> None:
         for row in rows
     ]
 
-    results = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[AgentEvaluator()],
+    )
+    results = await evaluate_suites(
+        suites=[suite],
     )
     print(json.dumps(results, indent=2))
 

--- a/gen-ai/tutorials/evaluations/agent_evaluation_tutorial/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/agent_evaluation_tutorial/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_csv/example_dataset_from_csv.py
+++ b/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_csv/example_dataset_from_csv.py
@@ -14,7 +14,7 @@ async def main():
             expected_output=row["expected_response"],
             retrieved_context=your_ai_func_result(row["query"])["retrieved_context"],
         )
-        for row in DictDataset.from_csv("examples/sample_data/simple_qa_data.csv").load()
+        for row in DictDataset.from_csv("examples/simple_qa_data.csv").load()
     ]
 
 

--- a/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_csv/examples/simple_qa_data.csv
+++ b/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_csv/examples/simple_qa_data.csv
@@ -1,0 +1,4 @@
+question_id,query,generated_response,expected_response,retrieved_context
+"1","What is the capital of France?","The capital of France is Paris.","Paris","France is a country in Europe. Paris is the capital and largest city of France."
+"2","What is 2+2?","4","4","Basic arithmetic: 2+2 equals 4."
+"3","What is the largest planet in our solar system?","Jupiter","Jupiter","Jupiter is the fifth planet from the Sun and the largest in the Solar System." 

--- a/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_csv/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_csv/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_gsheets/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_gsheets/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_huggingface_hub/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_huggingface_hub/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_langfuse/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/dataset/dict_dataset_from_langfuse/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/dataset/langfuse_dataset_generation/example_langfuse_dataset_generation.py
+++ b/gen-ai/tutorials/evaluations/dataset/langfuse_dataset_generation/example_langfuse_dataset_generation.py
@@ -1,11 +1,10 @@
 import asyncio
 
-from langfuse import Langfuse, get_client
-
-from gllm_evals import LLMTestCase, evaluate
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.dataset.dict_dataset import DictDataset
 from gllm_evals.dataset.langfuse_dataset import LangfuseDataset
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
+from langfuse import Langfuse, get_client
 
 
 async def main():
@@ -32,7 +31,13 @@ async def main():
         for row in dataset
     ]
 
-    results = await evaluate(data=data, evaluators=[evaluator])
+    suite = EvalSuite(
+        data=data,
+        evaluators=[evaluator],
+    )
+    results = await evaluate_suites(
+        suites=[suite],
+    )
     print(results)
 
 

--- a/gen-ai/tutorials/evaluations/dataset/langfuse_dataset_generation/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/dataset/langfuse_dataset_generation/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_from_google_sheets/evaluate_from_google_sheets.py
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_from_google_sheets/evaluate_from_google_sheets.py
@@ -2,9 +2,8 @@ import asyncio
 import os
 
 from dotenv import load_dotenv
-from gllm_evals import LLMTestCase
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.dataset.spreadsheet_dataset import SpreadsheetDataset
-from gllm_evals.evaluate import evaluate
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
 from inference_mock import your_ai_func_result
 
@@ -37,9 +36,12 @@ async def main() -> None:
         for row in dataset
     ]
 
-    results = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[GEvalGenerationEvaluator()],
+    )
+    results = await evaluate_suites(
+        suites=[suite],
     )
     print(results)
 

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_from_google_sheets/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_from_google_sheets/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_standard/evaluate_standard.py
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_standard/evaluate_standard.py
@@ -1,8 +1,7 @@
 import asyncio
 
-from gllm_evals import LLMTestCase
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.dataset.dict_dataset import DictDataset
-from gllm_evals.evaluate import evaluate
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
 from gllm_evals.experiment_tracker import CSVExperimentTracker
 from inference_mock import your_ai_func_result
@@ -25,9 +24,12 @@ async def main() -> None:
         )
         for row in DictDataset.from_csv("dataset_examples/simple_qa_data.csv").load()
     ]
-    results = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[GEvalGenerationEvaluator()],
+    )
+    results = await evaluate_suites(
+        suites=[suite],
         experiment_tracker=CSVExperimentTracker(project_name="evals_test"),
     )
     print(results)

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_standard/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_standard/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_langfuse/evaluate_with_langfuse.py
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_langfuse/evaluate_with_langfuse.py
@@ -2,9 +2,8 @@ import asyncio
 import os
 
 from dotenv import load_dotenv
-from gllm_evals import LLMTestCase
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.dataset.spreadsheet_dataset import SpreadsheetDataset
-from gllm_evals.evaluate import evaluate
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
 from gllm_evals.experiment_tracker.langfuse_experiment_tracker import (
     LangfuseExperimentTracker,
@@ -45,7 +44,7 @@ async def main() -> None:
 
     data = [
         LLMTestCase(
-            question_id=row['question_id'],
+            question_id=row["question_id"],
             input=row["input"],
             actual_output=your_ai_func_result(row["input"])["actual output"],
             expected_output=row["expected_output"],
@@ -54,9 +53,12 @@ async def main() -> None:
         for row in dataset
     ]
 
-    results = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[GEvalGenerationEvaluator()],
+    )
+    results = await evaluate_suites(
+        suites=[suite],
         experiment_tracker=LangfuseExperimentTracker(
             langfuse_client=get_client(),
             mapping=mapping,

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_langfuse/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_langfuse/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_summary/evaluate_with_summary.py
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_summary/evaluate_with_summary.py
@@ -1,9 +1,8 @@
 import asyncio
 import json
 
-from gllm_evals import LLMTestCase
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.dataset.dict_dataset import DictDataset
-from gllm_evals.evaluate import evaluate
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
 from gllm_evals.metrics.generation.geval_completeness import GEvalCompletenessMetric
 from gllm_evals.metrics.generation.geval_redundancy import GEvalRedundancyMetric
@@ -49,14 +48,17 @@ async def main():
         )
         for row in DictDataset.from_csv("dataset_examples/simple_qa_data.csv").load()
     ]
-    result = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[
             GEvalGenerationEvaluator(
                 metrics=[GEvalCompletenessMetric(), GEvalRedundancyMetric()]
             )
         ],
-        summary_evaluators=[
+    )
+    result = await evaluate_suites(
+        suites=[suite],
+        run_aggregators=[
             accuracy_summary,
         ],
         batch_size=1,

--- a/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_summary/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_helper_function/evaluate_with_summary/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_binary_classification/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_binary_classification/pyproject.toml
@@ -5,7 +5,7 @@ description = "Example: evaluate_suites with binary classification (TPR/TNR) run
 requires-python = ">=3.11"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain]>=0.1.18,<0.2.0",
     "gllm-inference>=0.6.0",
 ]
 

--- a/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_standard/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_standard/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
     "gllm-inference>=0.6.0",
 ]
 

--- a/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_with_google_sheets_experiment_tracker/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_with_google_sheets_experiment_tracker/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
     "gllm-inference>=0.6.0",
 ]
 

--- a/gen-ai/tutorials/evaluations/evaluator/classical_retrieval_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/classical_retrieval_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/composite_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/composite_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/create_custom_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/create_custom_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/geval_generation_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/geval_generation_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/lm_based_retrieval_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/lm_based_retrieval_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/metrics_aggregator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/metrics_aggregator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/query_transformer_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/query_transformer_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/evaluator/summarization_evaluator/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/evaluator/summarization_evaluator/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/getting_started/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/getting_started/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/metrics/custom_metric/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/metrics/custom_metric/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/metrics/modify_metrics/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/metrics/modify_metrics/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/metrics/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/metrics/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/multiple_llm_as_a_judge/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/multiple_llm_as_a_judge/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11,<3.14"
 readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/tutorials/custom_evaluator_tutorial/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/tutorials/custom_evaluator_tutorial/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 dependencies = [
     "python-dotenv>=1.0.0,<2.0.0",
     "pandas>=2.0.0",
-    "gllm-evals[deepeval,langchain,ragas]>=0.1.9,<0.2.0",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
 ]
 
 [[tool.uv.index]]

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 
 from dotenv import load_dotenv
-from gllm_evals import LLMTestCase, evaluate
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.constant import DefaultValues
 from gllm_evals.dataset.dict_dataset import DictDataset
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
@@ -23,7 +23,9 @@ from gllm_evals.experiment_tracker.csv_experiment_tracker import CSVExperimentTr
 from gllm_evals.metrics.generation.geval_completeness import GEvalCompletenessMetric
 from gllm_evals.metrics.generation.geval_groundedness import GEvalGroundednessMetric
 from gllm_evals.metrics.generation.geval_redundancy import GEvalRedundancyMetric
-from gllm_evals.metrics.tool_use.deepeval_tool_correctness import DeepEvalToolCorrectnessMetric
+from gllm_evals.metrics.tool_use.deepeval_tool_correctness import (
+    DeepEvalToolCorrectnessMetric,
+)
 from gllm_evals.types import ToolCall
 from gllm_inference.lm_invoker import build_lm_invoker
 
@@ -73,7 +75,11 @@ MOCK_AGENT_OUTPUTS: dict[str, tuple[str, list[dict]]] = {
                 "output": {
                     # Note: Ruby and Rust absent — tool retrieval gap
                     "supported_languages": [
-                        "Python", "JavaScript", "TypeScript", "Java", "Go"
+                        "Python",
+                        "JavaScript",
+                        "TypeScript",
+                        "Java",
+                        "Go",
                     ],
                 },
             }
@@ -108,7 +114,9 @@ async def main():
             tools_called=ToolCall.from_dicts(tools_called_list),
             expected_tools=ToolCall.from_dicts(json.loads(row["expected_tools"])),
         )
-        for row, (actual_output, tools_called_list, retrieved_context) in zip(DATASET, agent_results)
+        for row, (actual_output, tools_called_list, retrieved_context) in zip(
+            DATASET, agent_results
+        )
     ]
 
     judge_model = build_lm_invoker(model_id=DefaultValues.MODEL)
@@ -118,7 +126,7 @@ async def main():
         include_eval_result=True,
     )
     # Use default generation metrics + tool_correctness (dataset has expected_tools).
-    experiment_result = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[
             GEvalGenerationEvaluator(
@@ -131,6 +139,9 @@ async def main():
                 ],
             )
         ],
+    )
+    experiment_result = await evaluate_suites(
+        suites=[suite],
         experiment_tracker=tracker,
     )
     print(experiment_result)

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval_calibrated.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval_calibrated.py
@@ -24,16 +24,20 @@ import asyncio
 import json
 
 from dotenv import load_dotenv
-from gllm_evals import LLMTestCase, evaluate
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.constant import DefaultValues
-from gllm_evals.types import ToolCall
 from gllm_evals.dataset.dict_dataset import DictDataset
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
 from gllm_evals.experiment_tracker.csv_experiment_tracker import CSVExperimentTracker
 from gllm_evals.metrics.generation.geval_groundedness import GEvalGroundednessMetric
 from gllm_evals.metrics.generation.geval_redundancy import GEvalRedundancyMetric
-from gllm_evals.metrics.retrieval.geval_context_sufficiency import GEvalContextSufficiencyMetric
-from gllm_evals.metrics.tool_use.deepeval_tool_correctness import DeepEvalToolCorrectnessMetric
+from gllm_evals.metrics.retrieval.geval_context_sufficiency import (
+    GEvalContextSufficiencyMetric,
+)
+from gllm_evals.metrics.tool_use.deepeval_tool_correctness import (
+    DeepEvalToolCorrectnessMetric,
+)
+from gllm_evals.types import ToolCall
 from gllm_inference.lm_invoker import build_lm_invoker
 
 load_dotenv()
@@ -80,7 +84,11 @@ MOCK_AGENT_OUTPUTS: dict[str, tuple[str, list[dict]]] = {
                 "output": {
                     # Note: Ruby and Rust absent — tool retrieval gap
                     "supported_languages": [
-                        "Python", "JavaScript", "TypeScript", "Java", "Go"
+                        "Python",
+                        "JavaScript",
+                        "TypeScript",
+                        "Java",
+                        "Go",
                     ],
                 },
             }
@@ -112,7 +120,9 @@ async def main():
             tools_called=ToolCall.from_dicts(tools_called_list),
             expected_tools=ToolCall.from_dicts(json.loads(row["expected_tools"])),
         )
-        for row, (actual_output, tools_called_list, retrieved_context) in zip(DATASET, agent_results)
+        for row, (actual_output, tools_called_list, retrieved_context) in zip(
+            DATASET, agent_results
+        )
     ]
 
     judge_model = build_lm_invoker(model_id=DefaultValues.MODEL)
@@ -126,7 +136,8 @@ async def main():
     # tool_correctness: did the agent call the right tool with the right args?
     # context_sufficiency: did the tool return enough data to answer the query?
     # Together they attribute failures to the agent layer vs the tool layer.
-    result_multi = await evaluate(
+    suite_multi = EvalSuite(
+        name="agent-qna-eval-multi",
         data=[data[0], data[2]],
         evaluators=[
             GEvalGenerationEvaluator(
@@ -139,17 +150,18 @@ async def main():
                 ],
             )
         ],
-        experiment_tracker=tracker,
     )
-    print(result_multi)
-
     # Case 2: single-value lookup — default (completeness + groundedness + redundancy).
-    result_single = await evaluate(
+    suite_single = EvalSuite(
+        name="agent-qna-eval-single",
         data=[data[1]],
         evaluators=[GEvalGenerationEvaluator(models=judge_model)],
+    )
+    result = await evaluate_suites(
+        suites=[suite_multi, suite_single],
         experiment_tracker=tracker,
     )
-    print(result_single)
+    print(result)
 
 
 if __name__ == "__main__":

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval_calibrated.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval_calibrated.py
@@ -132,33 +132,32 @@ async def main():
         include_eval_result=True,
     )
 
-    # Cases 1 and 3: multi-value enumeration queries.
-    # tool_correctness: did the agent call the right tool with the right args?
-    # context_sufficiency: did the tool return enough data to answer the query?
-    # Together they attribute failures to the agent layer vs the tool layer.
-    suite_multi = EvalSuite(
-        name="agent-qna-eval-multi",
-        data=[data[0], data[2]],
-        evaluators=[
-            GEvalGenerationEvaluator(
-                models=judge_model,
-                metrics=[
-                    DeepEvalToolCorrectnessMetric(),  # agent routing check — verify tool name only
-                    GEvalContextSufficiencyMetric(),  # tool data sufficiency check
-                    GEvalGroundednessMetric(),
-                    GEvalRedundancyMetric(),
-                ],
-            )
-        ],
-    )
-    # Case 2: single-value lookup — default (completeness + groundedness + redundancy).
-    suite_single = EvalSuite(
-        name="agent-qna-eval-single",
-        data=[data[1]],
-        evaluators=[GEvalGenerationEvaluator(models=judge_model)],
-    )
     result = await evaluate_suites(
-        suites=[suite_multi, suite_single],
+        suites=[
+            # Cases 1 and 3: tool_correctness checks agent routing, context_sufficiency
+            # checks tool data quality. Together they attribute failures to the right layer.
+            EvalSuite(
+                name="multi_metric",
+                data=[data[0], data[2]],
+                evaluators=[
+                    GEvalGenerationEvaluator(
+                        models=judge_model,
+                        metrics=[
+                            DeepEvalToolCorrectnessMetric(),  # verify tool name only
+                            GEvalContextSufficiencyMetric(),  # tool data sufficiency check
+                            GEvalGroundednessMetric(),
+                            GEvalRedundancyMetric(),
+                        ],
+                    )
+                ],
+            ),
+            # Case 2: single-value lookup — default (completeness + groundedness + redundancy).
+            EvalSuite(
+                name="single_lookup",
+                data=[data[1]],
+                evaluators=[GEvalGenerationEvaluator(models=judge_model)],
+            ),
+        ],
         experiment_tracker=tracker,
     )
     print(result)

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Agent Q&A evaluation example using GEvalGenerationEvaluator with tool-calling metrics"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "gllm-evals[deepeval,langchain,ragas]==0.1.14",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
     "python-dotenv>=1.0.0,<2.0.0",
 ]
 

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval.py
@@ -4,10 +4,10 @@ Authors:
     Daniel Adi (daniel.adi@gdplabs.id)
 
 References:
-    [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/your-first-rag-pipeline
+    [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/tutorials/evaluation/evals-lifecycle
 """
 
-import asyncio  # used by asyncio.run in __main__
+import asyncio
 
 from dotenv import load_dotenv
 from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval.py
@@ -10,7 +10,7 @@ References:
 import asyncio  # used by asyncio.run in __main__
 
 from dotenv import load_dotenv
-from gllm_evals import LLMTestCase, evaluate
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.constant import DefaultValues
 from gllm_evals.dataset.dict_dataset import DictDataset
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
@@ -155,6 +155,7 @@ MOCK_PIPELINE_OUTPUTS: dict[str, tuple[str, str]] = {
     ),
 }
 
+
 def run_pipeline(query: str) -> tuple[str, str]:
     """Return mock pipeline output for a query.
 
@@ -186,9 +187,12 @@ async def main():
         output_dir=OUTPUT_DIR,
         include_eval_result=True,
     )
-    experiment_result = await evaluate(
+    suite = EvalSuite(
         data=data,
         evaluators=[GEvalGenerationEvaluator(models=judge_model)],
+    )
+    experiment_result = await evaluate_suites(
+        suites=[suite],
         experiment_tracker=tracker,
     )
     print(experiment_result)

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval_calibrated.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval_calibrated.py
@@ -1,10 +1,19 @@
-"""Example script to evaluate a RAG pipeline using a mock pipeline.
+"""Example script to evaluate a RAG pipeline with calibrated metrics.
+
+Calibration for the browse query (Case 1):
+- Lower completeness threshold from 1.0 to 0.5.
+- Client confirmed that for browse queries, representative coverage is sufficient.
+- Lowering the threshold keeps the generation quality signal while adjusting the
+  pass criterion to real user expectations.
+
+Cases 2 and 3 (precise queries) keep the default evaluator. Single-fact answers
+have a stable reference where completeness at 1.0 is correct.
 
 Authors:
     Daniel Adi (daniel.adi@gdplabs.id)
 
 References:
-    [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/your-first-rag-pipeline
+    [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/tutorials/evaluation/evals-lifecycle
 """
 
 import asyncio  # used by asyncio.run in __main__
@@ -190,31 +199,31 @@ async def main():
         output_dir=OUTPUT_DIR,
         include_eval_result=True,
     )
-    # Case 1: relaxed completeness — browse query, representative coverage is sufficient.
-    suite_relaxed = EvalSuite(
-        name="rag-chatbot-eval-relaxed",
-        data=[data[0]],
-        evaluators=[
-            GEvalGenerationEvaluator(
-                models=judge_model,
-                metrics=[
-                    GEvalCompletenessMetric(
-                        threshold=0.5
-                    ),  # calibrated: accept partial coverage
-                    GEvalGroundednessMetric(),
-                    GEvalRedundancyMetric(),
-                ],
-            )
-        ],
-    )
-    # Cases 2-3: strict completeness (default threshold 1.0)
-    suite_strict = EvalSuite(
-        name="rag-chatbot-eval-strict",
-        data=data[1:],
-        evaluators=[GEvalGenerationEvaluator(models=judge_model)],
-    )
     result = await evaluate_suites(
-        suites=[suite_relaxed, suite_strict],
+        suites=[
+            # Case 1: browse query — completeness threshold lowered from 1.0 → 0.5 after client review.
+            # Client confirmed that for browse queries, representative coverage is sufficient.
+            EvalSuite(
+                name="browse_query",
+                data=[data[0]],
+                evaluators=[
+                    GEvalGenerationEvaluator(
+                        models=judge_model,
+                        metrics=[
+                            GEvalCompletenessMetric(threshold=0.5),  # calibrated: browse query
+                            GEvalGroundednessMetric(),
+                            GEvalRedundancyMetric(),
+                        ],
+                    )
+                ],
+            ),
+            # Cases 2-3: precise queries — default threshold (1.0) remains appropriate.
+            EvalSuite(
+                name="precise_queries",
+                data=data[1:],
+                evaluators=[GEvalGenerationEvaluator(models=judge_model)],
+            ),
+        ],
         experiment_tracker=tracker,
     )
     print(result)

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval_calibrated.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval_calibrated.py
@@ -10,7 +10,7 @@ References:
 import asyncio  # used by asyncio.run in __main__
 
 from dotenv import load_dotenv
-from gllm_evals import LLMTestCase, evaluate
+from gllm_evals import EvalSuite, LLMTestCase, evaluate_suites
 from gllm_evals.constant import DefaultValues
 from gllm_evals.dataset.dict_dataset import DictDataset
 from gllm_evals.evaluator.geval_generation_evaluator import GEvalGenerationEvaluator
@@ -158,6 +158,7 @@ MOCK_PIPELINE_OUTPUTS: dict[str, tuple[str, str]] = {
     ),
 }
 
+
 def run_pipeline(query: str) -> tuple[str, str]:
     """Return mock pipeline output for a query.
 
@@ -190,29 +191,33 @@ async def main():
         include_eval_result=True,
     )
     # Case 1: relaxed completeness — browse query, representative coverage is sufficient.
-    result1 = await evaluate(
+    suite_relaxed = EvalSuite(
+        name="rag-chatbot-eval-relaxed",
         data=[data[0]],
         evaluators=[
             GEvalGenerationEvaluator(
                 models=judge_model,
                 metrics=[
-                    GEvalCompletenessMetric(threshold=0.5),  # calibrated: accept partial coverage
+                    GEvalCompletenessMetric(
+                        threshold=0.5
+                    ),  # calibrated: accept partial coverage
                     GEvalGroundednessMetric(),
                     GEvalRedundancyMetric(),
                 ],
             )
         ],
-        experiment_tracker=tracker,
     )
-    print(result1)
-
     # Cases 2-3: strict completeness (default threshold 1.0)
-    result2 = await evaluate(
+    suite_strict = EvalSuite(
+        name="rag-chatbot-eval-strict",
         data=data[1:],
         evaluators=[GEvalGenerationEvaluator(models=judge_model)],
+    )
+    result = await evaluate_suites(
+        suites=[suite_relaxed, suite_strict],
         experiment_tracker=tracker,
     )
-    print(result2)
+    print(result)
 
 
 if __name__ == "__main__":

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/pyproject.toml
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 dependencies = [
     "gllm-core==0.4.24",
     "gllm-inference==0.6.29",
-    "gllm-evals[deepeval,langchain,ragas]==0.1.14",
+    "gllm-evals[deepeval,langchain,ragas]>=0.1.18,<0.2.0",
     "python-dotenv>=1.0.0,<2.0.0",
 ]
 


### PR DESCRIPTION
## Summary

- Migrate all tutorial examples from `evaluate()` to `EvalSuite` + `evaluate_suites()` API
- Bump `gllm-evals` dependency to `>=0.1.18,<0.2.0` across all tutorial `pyproject.toml` files
- Add `simple_qa_data.csv` sample dataset for the `dict_dataset_from_csv` tutorial
- Refactor `eval_calibrated.py` in `agent_qna_evaluations` and `rag_chatbot_evals` to use inline `EvalSuite` definitions inside `evaluate_suites()` calls — matching the Gitbook reference docs style
- Fix reference URLs and remove stale comments in `tutorials_by_task` eval scripts

## How to Test

1. Navigate to any updated tutorial directory (e.g., `gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals`)
2. Run `make sync` to install dependencies
3. Run `make run-eval` and `make run-eval-calibrated` — both should complete without errors
4. Verify output prints experiment results with `aggregate_success` fields

## Related Issues

N/A

## Author Checklist
- [x] Code follows team coding standards and style guide
- [x] Self-reviewed the code changes
- [ ] Added/updated tests for new functionality
- [x] All tests pass locally
- [x] Code is properly documented
- [x] Synced with latest `develop` branch
- [x] PR title follows conventional commit format
- [x] Meaningful commit messages used

## Additional Notes
1. [GDP Labs Coding and Code Review Best Practices](https://docs.google.com/document/d/1QCzqnxXPEN_fatbTaSt-LVL9vFKoEBrQ6zTCt3tbCWU/edit)