### PR TITLE
[A2UI] Bump Renderer to `0.3.0`

### DIFF
--- a/gen-ai/examples/a2ui/a2ui-nextjs/package-lock.json
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/package-lock.json
@@ -8,9 +8,9 @@
       "name": "agent-a2ui-compliant",
       "version": "0.1.0",
       "dependencies": {
-        "glchat-a2ui-react-renderer": "^0.2.7",
+        "glchat-a2ui-react-renderer": "^0.3.0",
         "lucide-react": "^0.575.0",
-        "next": "16.1.6",
+        "next": "^16.2.10",
         "react": "19.2.3",
         "react-dom": "19.2.3"
       },
@@ -78,12 +78,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -92,29 +93,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -131,13 +134,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -147,13 +151,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -163,36 +168,39 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -202,52 +210,57 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -257,31 +270,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -289,13 +304,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1037,9 +1053,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "16.1.6",
@@ -1051,12 +1068,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1066,12 +1084,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1081,12 +1100,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1096,12 +1116,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1111,12 +1132,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1126,12 +1148,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1141,12 +1164,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1156,12 +1180,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2010,10 +2035,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -2649,9 +2675,10 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -2681,9 +2708,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -2699,12 +2726,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2767,9 +2795,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001782",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2783,7 +2811,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3039,9 +3068,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3061,10 +3090,11 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
-      "dev": true
+      "version": "1.5.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
+      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3269,6 +3299,7 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3989,12 +4020,12 @@
       }
     },
     "node_modules/glchat-a2ui-react-renderer": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.2.7.tgz",
-      "integrity": "sha512-05i74SQbzDPAk/6Ephf6DPz6iP61xnyJEd4hGUji4RBMag4xL8EfNJtrEzQiQfw9MEGZPIHk54dtHfs54ywDcw==",
-      "hasInstallScript": true,
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.3.0.tgz",
+      "integrity": "sha512-rROX7R4hs9o8fc89ELHwIAlJkbfQ5U+0+sBVcTRwEpZJXRX+6gEuINKFpc7jcsB1a1CCALFrWFBsBBZAHhMqaQ==",
       "license": "MIT",
       "dependencies": {
+        "@a2ui/markdown-it": "^0.0.4",
         "@a2ui/react": "^0.10.0",
         "@a2ui/web_core": "^0.10.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -4006,7 +4037,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.563.0",
-        "patch-package": "^8.0.1"
+        "patch-package": "^8.0.1",
+        "zod": "^3.25.76"
       },
       "peerDependencies": {
         "react": ">=18.0.0"
@@ -5679,10 +5711,21 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5695,6 +5738,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6142,6 +6186,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -6252,15 +6297,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6290,13 +6336,14 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -6308,15 +6355,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -6387,10 +6434,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-      "dev": true
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6688,9 +6739,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -6706,8 +6757,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7879,6 +7931,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -8054,7 +8107,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
@@ -8150,37 +8204,37 @@
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       }
     },
     "@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -8190,129 +8244,129 @@
       }
     },
     "@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       }
     },
     "@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true
     },
     "@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "devOptional": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "devOptional": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       }
     },
     "@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "devOptional": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       }
     },
     "@emnapi/core": {
@@ -8724,9 +8778,9 @@
       }
     },
     "@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA=="
     },
     "@next/eslint-plugin-next": {
       "version": "16.1.6",
@@ -8738,51 +8792,51 @@
       }
     },
     "@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -9265,9 +9319,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -9669,9 +9723,9 @@
       "dev": true
     },
     "baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ=="
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw=="
     },
     "brace-expansion": {
       "version": "1.1.13",
@@ -9692,16 +9746,16 @@
       }
     },
     "browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "requires": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       }
     },
     "call-bind": {
@@ -9740,9 +9794,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001782",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -9918,9 +9972,9 @@
       }
     },
     "dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "requires": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -9936,9 +9990,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
+      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
       "dev": true
     },
     "emoji-regex": {
@@ -10625,10 +10679,11 @@
       }
     },
     "glchat-a2ui-react-renderer": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.2.7.tgz",
-      "integrity": "sha512-05i74SQbzDPAk/6Ephf6DPz6iP61xnyJEd4hGUji4RBMag4xL8EfNJtrEzQiQfw9MEGZPIHk54dtHfs54ywDcw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glchat-a2ui-react-renderer/-/glchat-a2ui-react-renderer-0.3.0.tgz",
+      "integrity": "sha512-rROX7R4hs9o8fc89ELHwIAlJkbfQ5U+0+sBVcTRwEpZJXRX+6gEuINKFpc7jcsB1a1CCALFrWFBsBBZAHhMqaQ==",
       "requires": {
+        "@a2ui/markdown-it": "^0.0.4",
         "@a2ui/react": "^0.10.0",
         "@a2ui/web_core": "^0.10.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -10640,7 +10695,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.563.0",
-        "patch-package": "^8.0.1"
+        "patch-package": "^8.0.1",
+        "zod": "^3.25.76"
       },
       "dependencies": {
         "@a2ui/react": {
@@ -11538,9 +11594,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -11868,9 +11924,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="
     },
     "napi-postinstall": {
       "version": "0.3.4",
@@ -11885,24 +11941,24 @@
       "dev": true
     },
     "next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "requires": {
-        "@next/env": "16.1.6",
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
+        "@next/env": "16.2.10",
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
-        "sharp": "^0.34.4",
+        "sharp": "^0.34.5",
         "styled-jsx": "5.1.6"
       },
       "dependencies": {
@@ -11931,9 +11987,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true
     },
     "object-assign": {
@@ -12137,12 +12193,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }

--- a/gen-ai/examples/a2ui/a2ui-nextjs/package.json
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/package.json
@@ -11,9 +11,9 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "glchat-a2ui-react-renderer": "^0.2.7",
+    "glchat-a2ui-react-renderer": "^0.3.0",
     "lucide-react": "^0.575.0",
-    "next": "16.1.6",
+    "next": "^16.2.10",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/app/layout.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/app/layout.tsx
@@ -1,5 +1,13 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { Inter } from "next/font/google";
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-sans",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "A2UI Chat Assistant",
@@ -12,7 +20,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.variable}>
       <head>
         {/* eslint-disable-next-line @next/next/no-page-custom-font */}
         <link
@@ -20,7 +28,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className="bg-white antialiased">{children}ii</body>
+      <body className="bg-white antialiased">{children}</body>
     </html>
   );
 }

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/components/ChatWindow.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/components/ChatWindow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { A2UIMessage } from "glchat-a2ui-react-renderer";
 import { ChatMessage } from "@/types/chat";
 import { useAutoScroll } from "@/hooks/useAutoScroll";
 import MessageList from "./chat/MessageList";
@@ -11,7 +12,7 @@ interface ChatWindowProps {
   onSendMessage: (content: string) => void;
   isLoading: boolean;
   streamingText: string;
-  streamingA2UIMessages: object[];
+  streamingA2UIMessages: A2UIMessage[];
 }
 
 export default function ChatWindow({

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/A2UIContent.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/A2UIContent.tsx
@@ -3,7 +3,7 @@
 import {
   type ActionPayload,
   A2UIMessage,
-  AllSurfacesRenderer,
+  SurfaceRenderer,
   Provider,
 } from "glchat-a2ui-react-renderer";
 
@@ -19,7 +19,7 @@ export function A2UIContent({
   };
   return (
     <Provider messages={messages} onAction={handleAction}>
-      <AllSurfacesRenderer />
+      <SurfaceRenderer />
     </Provider>
   );
 }

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/MessageBubble.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/MessageBubble.tsx
@@ -40,13 +40,13 @@ function TextContent({
 }
 
 // ---- A2UI Content Block ----
-function A2UIBlock({ messages }: Readonly<{ messages: object[] }>) {
+function A2UIBlock({ messages }: Readonly<{ messages: A2UIMessage[] }>) {
   if (messages.length === 0) return null;
 
   return (
     <div className="mt-3">
       <A2UIContent
-        messages={messages as A2UIMessage[]}
+        messages={messages}
         onUserAction={(action) => {
           console.log("User action:", action);
         }}
@@ -59,7 +59,7 @@ function A2UIBlock({ messages }: Readonly<{ messages: object[] }>) {
 interface MessageBubbleProps {
   message?: ChatMessage;
   streamingText?: string;
-  streamingA2UIMessages?: object[];
+  streamingA2UIMessages?: A2UIMessage[];
 }
 
 export default function MessageBubble({
@@ -84,8 +84,11 @@ export default function MessageBubble({
     a2uiMessages =
       streamingA2UIMessages ??
       message?.a2aResponse?.result.status.message.parts
-        .filter((p: A2APart) => p.kind === "data")
-        ?.map((p: A2APart) => p.data as A2UIMessage) ??
+        .filter(
+          (p): p is A2APart & { kind: "data"; data: A2UIMessage } =>
+            p.kind === "data" && p.data != null
+        )
+        .map((p) => p.data) ??
       [];
   }
   const isStreamingText = !!streamingText && streamingA2UIMessages?.length === 0;

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/StreamingBubble.tsx
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/components/chat/StreamingBubble.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { A2UIMessage } from "glchat-a2ui-react-renderer";
 import MessageBubble from "./MessageBubble";
 
 interface StreamingBubbleProps {
   streamingText: string;
-  streamingA2UIMessages: object[];
+  streamingA2UIMessages: A2UIMessage[];
 }
 
 export default function StreamingBubble({

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/hooks/useChat.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/hooks/useChat.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
+import { A2UIMessage } from "glchat-a2ui-react-renderer";
 import { simulateA2UIStream } from "@/utils/a2uiMockStream";
 import { A2AResponse, ChatMessage } from "@/types/chat";
 
@@ -13,7 +14,7 @@ export function useChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([initialMessage]);
   const [isLoading, setIsLoading] = useState(true);
   const [streamingText, setStreamingText] = useState("");
-  const [streamingA2UIMessages, setStreamingA2UIMessages] = useState<object[]>([]);
+  const [streamingA2UIMessages, setStreamingA2UIMessages] = useState<A2UIMessage[]>([]);
   const hasInit = useRef(false);
 
   const streamCallbacks = useCallback(
@@ -24,7 +25,7 @@ export function useChat() {
           if (part.kind === "text") {
             setStreamingText(part.text ?? "");
           } else if (part.kind === "data") {
-            setStreamingA2UIMessages((prev) => [...prev, part.data as object]);
+            setStreamingA2UIMessages((prev) => [...prev, part.data as A2UIMessage]);
           }
         }
       },

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/components.json
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/components.json
@@ -1,1346 +1,1144 @@
 [
   {
-    "surfaceUpdate": {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "main",
+      "catalogId": "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "main",
+      "value": {
+        "comp": {
+          "text": "Hello A2UI",
+          "bio": "A short bio for the longText field.",
+          "age": "28",
+          "dob": "1998-03-15",
+          "password": "",
+          "datetime": "2026-06-18T14:30:00.000Z",
+          "dateOnly": "2026-06-18",
+          "timeOnly": "2026-06-18T09:00:00.000Z",
+          "imageUrl": "https://picsum.photos/seed/catalog/24/24",
+          "volume": 50,
+          "timeoutExpires": "2026-12-31T23:59:59.000Z",
+          "downloadUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+          "checkbox": {
+            "value": true,
+            "label": "Enable email notifications"
+          },
+          "mcSingleChip": ["en"],
+          "mcSingleCheckbox": ["pro"],
+          "mcMultiChip": ["mon", "wed", "fri"],
+          "mcMultiCheckbox": ["design", "frontend"],
+          "tags": ["TypeScript", "A2UI"],
+          "listItems": [
+            {
+              "label": "Dynamic list item 1"
+            },
+            {
+              "label": "Dynamic list item 2"
+            },
+            {
+              "label": "Dynamic list item 3"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
       "surfaceId": "main",
       "components": [
         {
           "id": "root",
-          "component": { "Card": { "child": "comp-content" } }
+          "component": "Card",
+          "child": "comp-content"
         },
         {
           "id": "comp-content",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": [
-                  "comp-header",
-                  "comp-caption",
-                  "div-0",
-                  "label-01",
-                  "text-showcase",
-                  "div-01",
-                  "label-02",
-                  "image-showcase",
-                  "div-02",
-                  "label-03",
-                  "icon-showcase",
-                  "div-03",
-                  "label-04",
-                  "catalog-video",
-                  "div-04",
-                  "label-05",
-                  "catalog-audio",
-                  "div-05",
-                  "label-06",
-                  "demo-row",
-                  "div-06",
-                  "label-07",
-                  "demo-column",
-                  "div-07",
-                  "label-08",
-                  "catalog-list",
-                  "div-08",
-                  "label-09",
-                  "demo-card",
-                  "div-09",
-                  "label-10",
-                  "catalog-tabs",
-                  "div-10",
-                  "label-11",
-                  "divider-h",
-                  "divider-v-row",
-                  "div-11",
-                  "label-12",
-                  "catalog-modal",
-                  "div-12",
-                  "label-13",
-                  "actions-primary-row",
-                  "div-13",
-                  "label-14",
-                  "destructive-btn",
-                  "div-14",
-                  "label-15",
-                  "catalog-button-as-link",
-                  "div-15",
-                  "label-16",
-                  "catalog-checkbox",
-                  "div-16",
-                  "label-17",
-                  "textfield-showcase",
-                  "div-17",
-                  "label-18",
-                  "datetime-showcase",
-                  "div-18",
-                  "label-19",
-                  "mc-showcase",
-                  "div-19",
-                  "label-20",
-                  "catalog-slider",
-                  "div-20",
-                  "label-21",
-                  "taginput-caption",
-                  "catalog-taginput",
-                  "div-21",
-                  "label-22",
-                  "timeout-caption",
-                  "catalog-timeout",
-                  "div-bottom",
-                  "btn-row"
-                ]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
+          "component": "Column",
+          "children": [
+            "comp-header",
+            "comp-caption",
+            "div-0",
+            "label-01",
+            "text-showcase",
+            "div-01",
+            "label-02",
+            "image-showcase",
+            "div-02",
+            "label-03",
+            "icon-showcase",
+            "div-03",
+            "label-04",
+            "catalog-video",
+            "div-04",
+            "label-05",
+            "catalog-audio",
+            "div-05",
+            "label-06",
+            "demo-row",
+            "div-06",
+            "label-07",
+            "demo-column",
+            "div-07",
+            "label-08",
+            "catalog-list",
+            "div-08",
+            "label-09",
+            "demo-card",
+            "div-09",
+            "label-10",
+            "catalog-tabs",
+            "div-10",
+            "label-11",
+            "divider-h",
+            "divider-v-row",
+            "div-11",
+            "label-12",
+            "catalog-modal",
+            "div-12",
+            "label-13",
+            "button-showcase",
+            "div-13",
+            "label-14",
+            "catalog-checkbox",
+            "div-14",
+            "label-15",
+            "textfield-showcase",
+            "div-15",
+            "label-16",
+            "datetime-showcase",
+            "div-16",
+            "label-17",
+            "mc-showcase",
+            "div-17",
+            "label-18",
+            "catalog-slider",
+            "div-18",
+            "label-19",
+            "taginput-caption",
+            "catalog-taginput",
+            "div-19",
+            "label-20",
+            "timeout-caption",
+            "catalog-timeout",
+            "div-bottom",
+            "btn-row"
+          ],
+          "justify": "start",
+          "align": "stretch"
         },
-
         {
           "id": "comp-header",
-          "component": {
-            "Text": {
-              "text": { "literalString": "GLChat Standard Catalog" },
-              "usageHint": "h1"
-            }
-          }
+          "component": "Text",
+          "text": "GLChat Standard Catalog",
+          "variant": "h1"
         },
         {
           "id": "comp-caption",
-          "component": {
-            "Text": {
-              "text": {
-                "literalString": "All 22 components from glchat_standard_catalog_definition.json — typography, layout, media, overlays, actions, and form controls."
-              },
-              "usageHint": "caption"
-            }
-          }
+          "component": "Text",
+          "text": "All 20 components from glchat_standard_catalog_definition.json — typography, layout, media, overlays, actions, and form controls.",
+          "variant": "caption"
         },
-        { "id": "div-0", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-0",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-01",
-          "component": {
-            "Text": {
-              "text": { "literalString": "01 · Text" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "01 · Text",
+          "variant": "h3"
         },
         {
           "id": "text-showcase",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": [
-                  "text-h1",
-                  "text-h2",
-                  "text-h3",
-                  "text-h4",
-                  "text-h5",
-                  "text-body",
-                  "text-caption"
-                ]
-              },
-              "distribution": "start",
-              "alignment": "start"
-            }
-          }
+          "component": "Column",
+          "children": [
+            "text-h1",
+            "text-h2",
+            "text-h3",
+            "text-h4",
+            "text-h5",
+            "text-body",
+            "text-caption"
+          ],
+          "justify": "start",
+          "align": "start"
         },
         {
           "id": "text-h1",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Heading 1 — usageHint: h1" },
-              "usageHint": "h1"
-            }
-          }
+          "component": "Text",
+          "text": "Heading 1 — variant: h1",
+          "variant": "h1"
         },
         {
           "id": "text-h2",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Heading 2 — usageHint: h2" },
-              "usageHint": "h2"
-            }
-          }
+          "component": "Text",
+          "text": "Heading 2 — variant: h2",
+          "variant": "h2"
         },
         {
           "id": "text-h3",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Heading 3 — usageHint: h3" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "Heading 3 — variant: h3",
+          "variant": "h3"
         },
         {
           "id": "text-h4",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Heading 4 — usageHint: h4" },
-              "usageHint": "h4"
-            }
-          }
+          "component": "Text",
+          "text": "Heading 4 — variant: h4",
+          "variant": "h4"
         },
         {
           "id": "text-h5",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Heading 5 — usageHint: h5" },
-              "usageHint": "h5"
-            }
-          }
+          "component": "Text",
+          "text": "Heading 5 — variant: h5",
+          "variant": "h5"
         },
         {
           "id": "text-body",
-          "component": {
-            "Text": {
-              "text": {
-                "literalString": "Body text supports simple **markdown** formatting for emphasis."
-              },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Body text supports simple **markdown** formatting for emphasis.",
+          "variant": "body"
         },
         {
           "id": "text-caption",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Caption — smaller supporting text" },
-              "usageHint": "caption"
-            }
-          }
+          "component": "Text",
+          "text": "Caption — smaller supporting text",
+          "variant": "caption"
         },
-        { "id": "div-01", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-01",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-02",
-          "component": {
-            "Text": {
-              "text": { "literalString": "02 · Image" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "02 · Image",
+          "variant": "h3"
         },
         {
           "id": "image-showcase",
-          "component": {
-            "Row": {
-              "children": {
-                "explicitList": ["img-icon", "img-avatar", "img-feature"]
-              },
-              "distribution": "start",
-              "alignment": "center"
-            }
-          }
+          "component": "Row",
+          "children": ["img-icon", "img-avatar", "img-feature"],
+          "justify": "start",
+          "align": "center"
         },
         {
           "id": "img-icon",
-          "component": {
-            "Image": {
-              "url": { "literalString": "https://picsum.photos/seed/icon/48/48" },
-              "fit": "cover",
-              "usageHint": "icon"
-            }
-          }
+          "component": "Image",
+          "url": "https://picsum.photos/seed/icon/48/48",
+          "fit": "cover",
+          "variant": "icon"
         },
         {
           "id": "img-avatar",
-          "component": {
-            "Image": {
-              "url": { "literalString": "https://picsum.photos/seed/avatar/80/80" },
-              "fit": "cover",
-              "usageHint": "avatar"
-            }
-          }
+          "component": "Image",
+          "url": "https://picsum.photos/seed/avatar/80/80",
+          "fit": "cover",
+          "variant": "avatar"
         },
         {
           "id": "img-feature",
-          "component": {
-            "Image": {
-              "url": { "path": "/comp/imageUrl" },
-              "fit": "cover",
-              "usageHint": "mediumFeature"
-            }
-          }
+          "component": "Image",
+          "url": {
+            "path": "/comp/imageUrl"
+          },
+          "fit": "cover",
+          "variant": "mediumFeature"
         },
-        { "id": "div-02", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-02",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-03",
-          "component": {
-            "Text": {
-              "text": { "literalString": "03 · Icon" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "03 · Icon",
+          "variant": "h3"
         },
         {
           "id": "icon-showcase",
-          "component": {
-            "Row": {
-              "children": {
-                "explicitList": [
-                  "icon-check",
-                  "icon-error",
-                  "icon-warning",
-                  "icon-star",
-                  "icon-settings",
-                  "icon-home",
-                  "icon-search"
-                ]
-              },
-              "distribution": "start",
-              "alignment": "center"
-            }
-          }
+          "component": "Row",
+          "children": [
+            "icon-check",
+            "icon-error",
+            "icon-warning",
+            "icon-star",
+            "icon-settings",
+            "icon-home",
+            "icon-search"
+          ],
+          "justify": "start",
+          "align": "center"
         },
         {
           "id": "icon-check",
-          "component": { "Icon": { "name": { "literalString": "check" } } }
+          "component": "Icon",
+          "name": "check"
         },
         {
           "id": "icon-error",
-          "component": { "Icon": { "name": { "literalString": "error" } } }
+          "component": "Icon",
+          "name": "error"
         },
         {
           "id": "icon-warning",
-          "component": { "Icon": { "name": { "literalString": "warning" } } }
+          "component": "Icon",
+          "name": "warning"
         },
         {
           "id": "icon-star",
-          "component": { "Icon": { "name": { "literalString": "star" } } }
+          "component": "Icon",
+          "name": "star"
         },
         {
           "id": "icon-settings",
-          "component": { "Icon": { "name": { "literalString": "settings" } } }
+          "component": "Icon",
+          "name": "settings"
         },
         {
           "id": "icon-home",
-          "component": { "Icon": { "name": { "literalString": "home" } } }
+          "component": "Icon",
+          "name": "home"
         },
         {
           "id": "icon-search",
-          "component": { "Icon": { "name": { "literalString": "search" } } }
+          "component": "Icon",
+          "name": "search"
         },
-        { "id": "div-03", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-03",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-04",
-          "component": {
-            "Text": {
-              "text": { "literalString": "04 · Video" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "04 · Video",
+          "variant": "h3"
         },
         {
           "id": "catalog-video",
-          "component": {
-            "Video": {
-              "url": { "literalString": "https://www.w3schools.com/html/mov_bbb.mp4" }
-            }
-          }
+          "component": "Video",
+          "url": "https://www.w3schools.com/html/mov_bbb.mp4"
         },
-        { "id": "div-04", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-04",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-05",
-          "component": {
-            "Text": {
-              "text": { "literalString": "05 · AudioPlayer" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "05 · AudioPlayer",
+          "variant": "h3"
         },
         {
           "id": "catalog-audio",
-          "component": {
-            "AudioPlayer": {
-              "url": { "literalString": "https://www.w3schools.com/html/horse.mp3" },
-              "description": { "literalString": "Sample audio clip" }
-            }
-          }
+          "component": "AudioPlayer",
+          "url": "https://www.w3schools.com/html/horse.mp3",
+          "description": "Sample audio clip"
         },
-        { "id": "div-05", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-05",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-06",
-          "component": {
-            "Text": {
-              "text": { "literalString": "06 · Row" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "06 · Row",
+          "variant": "h3"
         },
         {
           "id": "demo-row",
-          "component": {
-            "Row": {
-              "children": {
-                "explicitList": ["row-left", "row-center", "row-right"]
-              },
-              "distribution": "spaceBetween",
-              "alignment": "center"
-            }
-          }
+          "component": "Row",
+          "children": ["row-left", "row-center", "row-right"],
+          "justify": "spaceBetween",
+          "align": "center"
         },
         {
           "id": "row-left",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Left" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Left",
+          "variant": "body"
         },
         {
           "id": "row-center",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Center" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Center",
+          "variant": "body"
         },
         {
           "id": "row-right",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Right" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Right",
+          "variant": "body"
         },
-        { "id": "div-06", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-06",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-07",
-          "component": {
-            "Text": {
-              "text": { "literalString": "07 · Column" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "07 · Column",
+          "variant": "h3"
         },
         {
           "id": "demo-column",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": ["col-item-1", "col-item-2", "col-item-3"]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
+          "component": "Column",
+          "children": ["col-item-1", "col-item-2", "col-item-3"],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "col-item-1",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Stacked item one" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Stacked item one",
+          "variant": "body"
         },
         {
           "id": "col-item-2",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Stacked item two" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Stacked item two",
+          "variant": "body"
         },
         {
           "id": "col-item-3",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Stacked item three" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Stacked item three",
+          "variant": "body"
         },
-        { "id": "div-07", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-07",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-08",
-          "component": {
-            "Text": {
-              "text": { "literalString": "08 · List" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "08 · List",
+          "variant": "h3"
         },
         {
           "id": "catalog-list",
-          "component": {
-            "List": {
-              "children": {
-                "template": {
-                  "componentId": "list-item-template",
-                  "dataBinding": "/comp/listItems"
-                }
-              },
-              "direction": "vertical",
-              "alignment": "start"
-            }
-          }
+          "component": "List",
+          "children": {
+            "componentId": "list-item-template",
+            "path": "/comp/listItems"
+          },
+          "direction": "vertical",
+          "align": "start"
         },
         {
           "id": "list-item-template",
-          "component": {
-            "Text": {
-              "text": { "path": "label" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": {
+            "path": "label"
+          },
+          "variant": "body"
         },
-        { "id": "div-08", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-08",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-09",
-          "component": {
-            "Text": {
-              "text": { "literalString": "09 · Card" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "09 · Card",
+          "variant": "h3"
         },
         {
           "id": "demo-card",
-          "component": {
-            "Card": { "child": "demo-card-inner" }
-          }
+          "component": "Card",
+          "child": "demo-card-inner"
         },
         {
           "id": "demo-card-inner",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": ["demo-card-title", "demo-card-body"]
-              },
-              "distribution": "start",
-              "alignment": "start"
-            }
-          }
+          "component": "Column",
+          "children": ["demo-card-title", "demo-card-body"],
+          "justify": "start",
+          "align": "start"
         },
         {
           "id": "demo-card-title",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Card title" },
-              "usageHint": "h4"
-            }
-          }
+          "component": "Text",
+          "text": "Card title",
+          "variant": "h4"
         },
         {
           "id": "demo-card-body",
-          "component": {
-            "Text": {
-              "text": {
-                "literalString": "A Card wraps a single child — often a Column or Row for grouped content."
-              },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "A Card wraps a single child — often a Column or Row for grouped content.",
+          "variant": "body"
         },
-        { "id": "div-09", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-09",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-10",
-          "component": {
-            "Text": {
-              "text": { "literalString": "10 · Tabs" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "10 · Tabs",
+          "variant": "h3"
         },
         {
           "id": "catalog-tabs",
-          "component": {
-            "Tabs": {
-              "tabItems": [
-                { "title": { "literalString": "Overview" }, "child": "tab-overview" },
-                { "title": { "literalString": "Details" }, "child": "tab-details" },
-                { "title": { "literalString": "Settings" }, "child": "tab-settings" }
-              ]
+          "component": "Tabs",
+          "tabs": [
+            {
+              "title": "Overview",
+              "child": "tab-overview"
+            },
+            {
+              "title": "Details",
+              "child": "tab-details"
+            },
+            {
+              "title": "Settings",
+              "child": "tab-settings"
             }
-          }
+          ]
         },
         {
           "id": "tab-overview",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Overview panel — summary information at a glance." },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Overview panel — summary information at a glance.",
+          "variant": "body"
         },
         {
           "id": "tab-details",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Details panel — extended metadata and specifications." },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Details panel — extended metadata and specifications.",
+          "variant": "body"
         },
         {
           "id": "tab-settings",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Settings panel — configuration options." },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Settings panel — configuration options.",
+          "variant": "body"
         },
-        { "id": "div-10", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-10",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-11",
-          "component": {
-            "Text": {
-              "text": { "literalString": "11 · Divider" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "11 · Divider",
+          "variant": "h3"
         },
-        { "id": "divider-h", "component": { "Divider": { "axis": "horizontal" } } },
+        {
+          "id": "divider-h",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "divider-v-row",
-          "component": {
-            "Row": {
-              "children": {
-                "explicitList": ["divider-v-left", "divider-v", "divider-v-right"]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
+          "component": "Row",
+          "children": ["divider-v-left", "divider-v", "divider-v-right"],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "divider-v-left",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Left of vertical divider" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Left of vertical divider",
+          "variant": "body"
         },
-        { "id": "divider-v", "component": { "Divider": { "axis": "vertical" } } },
+        {
+          "id": "divider-v",
+          "component": "Divider",
+          "axis": "vertical"
+        },
         {
           "id": "divider-v-right",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Right of vertical divider" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Right of vertical divider",
+          "variant": "body"
         },
-        { "id": "div-11", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-11",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "label-12",
-          "component": {
-            "Text": {
-              "text": { "literalString": "12 · Modal" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "12 · Modal",
+          "variant": "h3"
         },
         {
           "id": "catalog-modal",
-          "component": {
-            "Modal": {
-              "entryPointChild": "modal-open-btn",
-              "contentChild": "modal-body-col"
-            }
-          }
-        },
-        {
-          "id": "modal-open-btn",
-          "component": {
-            "Button": {
-              "child": "modal-open-text",
-              "action": { "name": "modal_open", "context": [] },
-              "primary": false
-            }
-          }
+          "component": "Modal",
+          "trigger": "modal-open-text",
+          "content": "modal-body-col"
         },
         {
           "id": "modal-open-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Open Modal" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Open Modal",
+          "variant": "body"
         },
         {
           "id": "modal-body-col",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": ["modal-title", "modal-body-text", "modal-close-btn"]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
+          "component": "Column",
+          "children": ["modal-title", "modal-body-text"],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "modal-title",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Modal Title" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "Modal Title",
+          "variant": "h3"
         },
         {
           "id": "modal-body-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Content rendered inside the modal overlay." },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Content rendered inside the modal overlay. Close with × or by clicking outside.",
+          "variant": "body"
         },
         {
-          "id": "modal-close-btn",
-          "component": {
-            "Button": {
-              "child": "modal-close-text",
-              "action": { "name": "modal_close", "context": [] },
-              "primary": true
-            }
-          }
+          "id": "div-12",
+          "component": "Divider",
+          "axis": "horizontal"
         },
-        {
-          "id": "modal-close-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Close" },
-              "usageHint": "body"
-            }
-          }
-        },
-        { "id": "div-12", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
           "id": "label-13",
-          "component": {
-            "Text": {
-              "text": { "literalString": "13 · Button" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "13 · Button",
+          "variant": "h3"
+        },
+        {
+          "id": "button-showcase",
+          "component": "Column",
+          "children": ["actions-primary-row", "catalog-button-as-link"],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "actions-primary-row",
-          "component": {
-            "Row": {
-              "children": {
-                "explicitList": ["btn-primary", "btn-secondary"]
-              },
-              "distribution": "start",
-              "alignment": "center"
-            }
-          }
+          "component": "Row",
+          "children": ["btn-primary", "btn-secondary", "destructive-btn", "btn-open-url"],
+          "justify": "start",
+          "align": "center"
         },
         {
           "id": "btn-primary",
-          "component": {
-            "Button": {
-              "child": "btn-primary-text",
-              "action": { "name": "primary_action", "context": [] },
-              "primary": true
+          "component": "Button",
+          "child": "btn-primary-text",
+          "action": {
+            "event": {
+              "name": "primary_action"
             }
-          }
+          },
+          "variant": "primary"
         },
         {
           "id": "btn-primary-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Primary" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Primary",
+          "variant": "body"
         },
         {
           "id": "btn-secondary",
-          "component": {
-            "Button": {
-              "child": "btn-secondary-text",
-              "action": { "name": "secondary_action", "context": [] },
-              "primary": false
+          "component": "Button",
+          "child": "btn-secondary-text",
+          "action": {
+            "event": {
+              "name": "secondary_action"
             }
-          }
+          },
+          "variant": "default"
         },
         {
           "id": "btn-secondary-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Secondary" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Secondary",
+          "variant": "body"
         },
-        { "id": "div-13", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-14",
-          "component": {
-            "Text": {
-              "text": { "literalString": "14 · DestructiveButton" },
-              "usageHint": "h3"
+          "id": "btn-open-url",
+          "component": "Button",
+          "child": "btn-open-url-text",
+          "action": {
+            "functionCall": {
+              "call": "openUrl",
+              "args": {
+                "url": "https://a2ui.org"
+              }
             }
-          }
+          },
+          "variant": "borderless"
+        },
+        {
+          "id": "btn-open-url-text",
+          "component": "Text",
+          "text": "Open docs",
+          "variant": "body"
         },
         {
           "id": "destructive-btn",
-          "component": {
-            "DestructiveButton": {
-              "child": "destructive-btn-text",
-              "action": { "name": "delete_item", "context": [] }
+          "component": "Button",
+          "child": "destructive-btn-text",
+          "action": {
+            "event": {
+              "name": "delete_item"
             }
-          }
+          },
+          "variant": "destructive"
         },
         {
           "id": "destructive-btn-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Delete" },
-              "usageHint": "body"
-            }
-          }
-        },
-        { "id": "div-14", "component": { "Divider": { "axis": "horizontal" } } },
-
-        {
-          "id": "label-15",
-          "component": {
-            "Text": {
-              "text": { "literalString": "15 · ButtonAsLink" },
-              "usageHint": "h3"
-            }
-          }
+          "component": "Text",
+          "text": "Delete",
+          "variant": "body"
         },
         {
           "id": "catalog-button-as-link",
-          "component": {
-            "ButtonAsLink": {
-              "child": "catalog-button-as-link-text",
-              "href": { "path": "/comp/downloadUrl" },
-              "target": { "literalString": "_blank" }
+          "component": "Button",
+          "child": "catalog-button-as-link-text",
+          "action": {
+            "functionCall": {
+              "call": "openUrl",
+              "args": {
+                "url": {
+                  "path": "/comp/downloadUrl"
+                }
+              }
             }
-          }
+          },
+          "variant": "borderless"
         },
         {
           "id": "catalog-button-as-link-text",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Download sample file ↗" },
-              "usageHint": "body"
-            }
-          }
+          "component": "Text",
+          "text": "Download sample file ↗",
+          "variant": "body"
         },
-        { "id": "div-15", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-16",
-          "component": {
-            "Text": {
-              "text": { "literalString": "16 · CheckBox" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-13",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-14",
+          "component": "Text",
+          "text": "14 · CheckBox",
+          "variant": "h3"
         },
         {
           "id": "catalog-checkbox",
-          "component": {
-            "CheckBox": {
-              "label": { "path": "/comp/checkbox/label" },
-              "value": { "path": "/comp/checkbox/value" }
-            }
+          "component": "CheckBox",
+          "label": {
+            "path": "/comp/checkbox/label"
+          },
+          "value": {
+            "path": "/comp/checkbox/value"
           }
         },
-        { "id": "div-16", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-17",
-          "component": {
-            "Text": {
-              "text": { "literalString": "17 · TextField" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-14",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-15",
+          "component": "Text",
+          "text": "15 · TextField",
+          "variant": "h3"
         },
         {
           "id": "textfield-showcase",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": [
-                  "tf-short",
-                  "tf-long",
-                  "tf-number",
-                  "tf-date",
-                  "tf-obscured"
-                ]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
+          "component": "Column",
+          "children": ["tf-short", "tf-long", "tf-number", "tf-date", "tf-obscured"],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "tf-short",
-          "component": {
-            "TextField": {
-              "label": { "literalString": "Short text" },
-              "text": { "path": "/comp/text" },
-              "textFieldType": "shortText"
-            }
-          }
+          "component": "TextField",
+          "label": "Short text",
+          "value": {
+            "path": "/comp/text"
+          },
+          "variant": "shortText"
         },
         {
           "id": "tf-long",
-          "component": {
-            "TextField": {
-              "label": { "literalString": "Long text" },
-              "text": { "path": "/comp/bio" },
-              "textFieldType": "longText"
-            }
-          }
+          "component": "TextField",
+          "label": "Long text",
+          "value": {
+            "path": "/comp/bio"
+          },
+          "variant": "longText"
         },
         {
           "id": "tf-number",
-          "component": {
-            "TextField": {
-              "label": { "literalString": "Number" },
-              "text": { "path": "/comp/age" },
-              "textFieldType": "number"
-            }
-          }
+          "component": "TextField",
+          "label": "Number",
+          "value": {
+            "path": "/comp/age"
+          },
+          "variant": "number"
         },
         {
           "id": "tf-date",
-          "component": {
-            "TextField": {
-              "label": { "literalString": "Date" },
-              "text": { "path": "/comp/dob" },
-              "textFieldType": "date"
-            }
-          }
+          "component": "DateTimeInput",
+          "label": "Date",
+          "value": {
+            "path": "/comp/dob"
+          },
+          "enableDate": true,
+          "enableTime": false
         },
         {
           "id": "tf-obscured",
-          "component": {
-            "TextField": {
-              "label": { "literalString": "Password (obscured)" },
-              "text": { "path": "/comp/password" },
-              "textFieldType": "obscured"
-            }
-          }
+          "component": "TextField",
+          "label": "Password (obscured)",
+          "value": {
+            "path": "/comp/password"
+          },
+          "variant": "obscured"
         },
-        { "id": "div-17", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-18",
-          "component": {
-            "Text": {
-              "text": { "literalString": "18 · DateTimeInput" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-15",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-16",
+          "component": "Text",
+          "text": "16 · DateTimeInput",
+          "variant": "h3"
         },
         {
           "id": "datetime-showcase",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": ["dt-datetime", "dt-date-only", "dt-time-only"]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
+          "component": "Column",
+          "children": ["dt-datetime", "dt-date-only", "dt-time-only"],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "dt-datetime",
-          "component": {
-            "DateTimeInput": {
-              "value": { "path": "/comp/datetime" },
-              "enableDate": true,
-              "enableTime": true
-            }
-          }
+          "component": "DateTimeInput",
+          "label": "Date & time",
+          "value": {
+            "path": "/comp/datetime"
+          },
+          "enableDate": true,
+          "enableTime": true
         },
         {
           "id": "dt-date-only",
-          "component": {
-            "DateTimeInput": {
-              "value": { "path": "/comp/dateOnly" },
-              "enableDate": true,
-              "enableTime": false
-            }
-          }
+          "component": "DateTimeInput",
+          "label": "Date only",
+          "value": {
+            "path": "/comp/dateOnly"
+          },
+          "enableDate": true,
+          "enableTime": false
         },
         {
           "id": "dt-time-only",
-          "component": {
-            "DateTimeInput": {
-              "value": { "path": "/comp/timeOnly" },
-              "enableDate": false,
-              "enableTime": true
-            }
-          }
+          "component": "DateTimeInput",
+          "label": "Time only",
+          "value": {
+            "path": "/comp/timeOnly"
+          },
+          "enableDate": false,
+          "enableTime": true
         },
-        { "id": "div-18", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-19",
-          "component": {
-            "Text": {
-              "text": { "literalString": "19 · MultipleChoice" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-16",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-17",
+          "component": "Text",
+          "text": "17 · ChoicePicker",
+          "variant": "h3"
         },
         {
           "id": "mc-showcase",
-          "component": {
-            "Column": {
-              "children": {
-                "explicitList": [
-                  "mc-single-chip-label",
-                  "mc-single-chip",
-                  "mc-single-checkbox-label",
-                  "mc-single-checkbox",
-                  "mc-multi-chip-label",
-                  "mc-multi-chip",
-                  "mc-multi-checkbox-label",
-                  "mc-multi-checkbox"
-                ]
-              },
-              "distribution": "start",
-              "alignment": "stretch"
-            }
-          }
-        },
-        {
-          "id": "mc-single-chip-label",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Single select · chips" },
-              "usageHint": "caption"
-            }
-          }
+          "component": "Column",
+          "children": [
+            "mc-single-chip",
+            "mc-single-checkbox",
+            "mc-multi-chip",
+            "mc-multi-checkbox"
+          ],
+          "justify": "start",
+          "align": "stretch"
         },
         {
           "id": "mc-single-chip",
-          "component": {
-            "MultipleChoice": {
-              "selections": { "path": "/comp/mcSingleChip" },
-              "type": "chips",
-              "maxAllowedSelections": 1,
-              "options": [
-                { "value": "en", "label": { "literalString": "English" } },
-                { "value": "id", "label": { "literalString": "Indonesian" } },
-                { "value": "ja", "label": { "literalString": "Japanese" } }
-              ]
+          "component": "ChoicePicker",
+          "label": "Single select · chips",
+          "options": [
+            {
+              "value": "en",
+              "label": "English"
+            },
+            {
+              "value": "id",
+              "label": "Indonesian"
+            },
+            {
+              "value": "ja",
+              "label": "Japanese"
             }
-          }
-        },
-        {
-          "id": "mc-single-checkbox-label",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Single select · checkbox" },
-              "usageHint": "caption"
-            }
-          }
+          ],
+          "value": {
+            "path": "/comp/mcSingleChip"
+          },
+          "displayStyle": "chips",
+          "variant": "mutuallyExclusive"
         },
         {
           "id": "mc-single-checkbox",
-          "component": {
-            "MultipleChoice": {
-              "selections": { "path": "/comp/mcSingleCheckbox" },
-              "type": "checkbox",
-              "maxAllowedSelections": 1,
-              "options": [
-                { "value": "free", "label": { "literalString": "Free" } },
-                { "value": "pro", "label": { "literalString": "Pro" } },
-                { "value": "enterprise", "label": { "literalString": "Enterprise" } }
-              ]
+          "component": "ChoicePicker",
+          "label": "Single select · checkbox",
+          "options": [
+            {
+              "value": "free",
+              "label": "Free"
+            },
+            {
+              "value": "pro",
+              "label": "Pro"
+            },
+            {
+              "value": "enterprise",
+              "label": "Enterprise"
             }
-          }
-        },
-        {
-          "id": "mc-multi-chip-label",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Multi select · chips" },
-              "usageHint": "caption"
-            }
-          }
+          ],
+          "value": {
+            "path": "/comp/mcSingleCheckbox"
+          },
+          "displayStyle": "checkbox",
+          "variant": "mutuallyExclusive"
         },
         {
           "id": "mc-multi-chip",
-          "component": {
-            "MultipleChoice": {
-              "selections": { "path": "/comp/mcMultiChip" },
-              "type": "chips",
-              "maxAllowedSelections": 4,
-              "options": [
-                { "value": "mon", "label": { "literalString": "Mon" } },
-                { "value": "tue", "label": { "literalString": "Tue" } },
-                { "value": "wed", "label": { "literalString": "Wed" } },
-                { "value": "thu", "label": { "literalString": "Thu" } },
-                { "value": "fri", "label": { "literalString": "Fri" } }
-              ]
+          "component": "ChoicePicker",
+          "label": "Multi select · chips",
+          "options": [
+            {
+              "value": "mon",
+              "label": "Mon"
+            },
+            {
+              "value": "tue",
+              "label": "Tue"
+            },
+            {
+              "value": "wed",
+              "label": "Wed"
+            },
+            {
+              "value": "thu",
+              "label": "Thu"
+            },
+            {
+              "value": "fri",
+              "label": "Fri"
             }
-          }
-        },
-        {
-          "id": "mc-multi-checkbox-label",
-          "component": {
-            "Text": {
-              "text": { "literalString": "Multi select · checkbox" },
-              "usageHint": "caption"
-            }
-          }
+          ],
+          "value": {
+            "path": "/comp/mcMultiChip"
+          },
+          "displayStyle": "chips",
+          "variant": "multipleSelection"
         },
         {
           "id": "mc-multi-checkbox",
-          "component": {
-            "MultipleChoice": {
-              "selections": { "path": "/comp/mcMultiCheckbox" },
-              "type": "checkbox",
-              "maxAllowedSelections": 3,
-              "options": [
-                { "value": "design", "label": { "literalString": "Design" } },
-                { "value": "frontend", "label": { "literalString": "Frontend" } },
-                { "value": "backend", "label": { "literalString": "Backend" } },
-                { "value": "devops", "label": { "literalString": "DevOps" } }
-              ]
+          "component": "ChoicePicker",
+          "label": "Multi select · checkbox",
+          "options": [
+            {
+              "value": "design",
+              "label": "Design"
+            },
+            {
+              "value": "frontend",
+              "label": "Frontend"
+            },
+            {
+              "value": "backend",
+              "label": "Backend"
+            },
+            {
+              "value": "devops",
+              "label": "DevOps"
             }
-          }
+          ],
+          "value": {
+            "path": "/comp/mcMultiCheckbox"
+          },
+          "displayStyle": "checkbox",
+          "variant": "multipleSelection"
         },
-        { "id": "div-19", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-20",
-          "component": {
-            "Text": {
-              "text": { "literalString": "20 · Slider" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-17",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-18",
+          "component": "Text",
+          "text": "18 · Slider",
+          "variant": "h3"
         },
         {
           "id": "catalog-slider",
-          "component": {
-            "Slider": {
-              "value": { "path": "/comp/volume" },
-              "minValue": 0,
-              "maxValue": 100
-            }
-          }
+          "component": "Slider",
+          "label": "Volume",
+          "value": {
+            "path": "/comp/volume"
+          },
+          "min": 0,
+          "max": 100
         },
-        { "id": "div-20", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-21",
-          "component": {
-            "Text": {
-              "text": { "literalString": "21 · TagInput" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-18",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-19",
+          "component": "Text",
+          "text": "19 · TagInput",
+          "variant": "h3"
         },
         {
           "id": "taginput-caption",
-          "component": {
-            "Text": {
-              "text": {
-                "literalString": "Type a tag and press Enter. Email validation via validationRegexp."
-              },
-              "usageHint": "caption"
-            }
-          }
+          "component": "Text",
+          "text": "Type a tag and press Enter. Email validation via validationRegexp.",
+          "variant": "caption"
         },
         {
           "id": "catalog-taginput",
-          "component": {
-            "TagInput": {
-              "label": { "literalString": "Skills" },
-              "values": { "path": "/comp/tags" },
-              "placeholder": { "literalString": "e.g. TypeScript" },
-              "validationRegexp": "^[a-zA-Z0-9+\\-\\. ]{2,32}$",
-              "validationErrorMessage": {
-                "literalString": "Tags must be 2–32 characters (letters, numbers, +, -, ., space)."
-              }
-            }
-          }
+          "component": "TagInput",
+          "label": "Skills",
+          "value": {
+            "path": "/comp/tags"
+          },
+          "placeholder": "e.g. TypeScript",
+          "validationRegexp": "^[a-zA-Z0-9+\\-\\. ]{2,32}$",
+          "validationErrorMessage": "Tags must be 2–32 characters (letters, numbers, +, -, ., space)."
         },
-        { "id": "div-21", "component": { "Divider": { "axis": "horizontal" } } },
-
         {
-          "id": "label-22",
-          "component": {
-            "Text": {
-              "text": { "literalString": "22 · Timeout" },
-              "usageHint": "h3"
-            }
-          }
+          "id": "div-19",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
+        {
+          "id": "label-20",
+          "component": "Text",
+          "text": "20 · Timeout",
+          "variant": "h3"
         },
         {
           "id": "timeout-caption",
-          "component": {
-            "Text": {
-              "text": {
-                "literalString": "Countdown to targetTimeUtc (ISO 8601). Updates live until the target is reached."
-              },
-              "usageHint": "caption"
-            }
-          }
+          "component": "Text",
+          "text": "Countdown to targetTimeUtc (ISO 8601). Updates live until the target is reached.",
+          "variant": "caption"
         },
         {
           "id": "catalog-timeout",
-          "component": {
-            "Timeout": {
-              "targetTimeUtc": { "path": "/comp/timeoutExpires" }
-            }
+          "component": "Timeout",
+          "targetTimeUtc": {
+            "path": "/comp/timeoutExpires"
           }
         },
-        { "id": "div-bottom", "component": { "Divider": { "axis": "horizontal" } } },
-
+        {
+          "id": "div-bottom",
+          "component": "Divider",
+          "axis": "horizontal"
+        },
         {
           "id": "btn-row",
-          "component": {
-            "Row": {
-              "children": { "explicitList": ["submit-btn"] },
-              "distribution": "end",
-              "alignment": "center"
-            }
-          }
+          "component": "Row",
+          "children": ["submit-btn"],
+          "justify": "end",
+          "align": "center"
         },
         {
           "id": "submit-btn",
-          "component": {
-            "Button": {
-              "child": "submit-text",
-              "action": {
-                "name": "catalog_submit",
-                "context": [
-                  { "key": "text", "value": { "path": "/comp/text" } },
-                  { "key": "bio", "value": { "path": "/comp/bio" } },
-                  { "key": "age", "value": { "path": "/comp/age" } },
-                  { "key": "dob", "value": { "path": "/comp/dob" } },
-                  { "key": "password", "value": { "path": "/comp/password" } },
-                  { "key": "checkbox", "value": { "path": "/comp/checkbox/value" } },
-                  { "key": "datetime", "value": { "path": "/comp/datetime" } },
-                  { "key": "mcSingleChip", "value": { "path": "/comp/mcSingleChip" } },
-                  { "key": "mcSingleCheckbox", "value": { "path": "/comp/mcSingleCheckbox" } },
-                  { "key": "mcMultiChip", "value": { "path": "/comp/mcMultiChip" } },
-                  { "key": "mcMultiCheckbox", "value": { "path": "/comp/mcMultiCheckbox" } },
-                  { "key": "volume", "value": { "path": "/comp/volume" } },
-                  { "key": "tags", "value": { "path": "/comp/tags" } }
-                ]
-              },
-              "primary": true
+          "component": "Button",
+          "child": "submit-text",
+          "action": {
+            "event": {
+              "name": "catalog_submit",
+              "context": {
+                "text": {
+                  "path": "/comp/text"
+                },
+                "bio": {
+                  "path": "/comp/bio"
+                },
+                "age": {
+                  "path": "/comp/age"
+                },
+                "dob": {
+                  "path": "/comp/dob"
+                },
+                "password": {
+                  "path": "/comp/password"
+                },
+                "checkbox": {
+                  "path": "/comp/checkbox/value"
+                },
+                "datetime": {
+                  "path": "/comp/datetime"
+                },
+                "mcSingleChip": {
+                  "path": "/comp/mcSingleChip"
+                },
+                "mcSingleCheckbox": {
+                  "path": "/comp/mcSingleCheckbox"
+                },
+                "mcMultiChip": {
+                  "path": "/comp/mcMultiChip"
+                },
+                "mcMultiCheckbox": {
+                  "path": "/comp/mcMultiCheckbox"
+                },
+                "volume": {
+                  "path": "/comp/volume"
+                },
+                "tags": {
+                  "path": "/comp/tags"
+                }
+              }
             }
-          }
+          },
+          "variant": "primary"
         },
         {
           "id": "submit-text",
-          "component": {
-            "Text": { "text": { "literalString": "Submit" }, "usageHint": "body" }
-          }
+          "component": "Text",
+          "text": "Submit",
+          "variant": "body"
         }
       ]
-    }
-  },
-  {
-    "dataModelUpdate": {
-      "surfaceId": "main",
-      "contents": [
-        {
-          "key": "comp",
-          "valueMap": [
-            { "key": "text", "valueString": "Hello A2UI" },
-            { "key": "bio", "valueString": "A short bio for the longText field." },
-            { "key": "age", "valueString": "28" },
-            { "key": "dob", "valueString": "1998-03-15" },
-            { "key": "password", "valueString": "" },
-            { "key": "datetime", "valueString": "2026-06-18T14:30:00.000Z" },
-            { "key": "dateOnly", "valueString": "2026-06-18" },
-            { "key": "timeOnly", "valueString": "2026-06-18T09:00:00.000Z" },
-            { "key": "imageUrl", "valueString": "https://picsum.photos/seed/catalog/640/360" },
-            { "key": "volume", "valueNumber": 50 },
-            { "key": "timeoutExpires", "valueString": "2026-12-31T23:59:59.000Z" },
-            {
-              "key": "downloadUrl",
-              "valueString": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
-            },
-            {
-              "key": "checkbox",
-              "valueMap": [
-                { "key": "value", "valueBoolean": true },
-                { "key": "label", "valueString": "Enable email notifications" }
-              ]
-            },
-            {
-              "key": "mcSingleChip",
-              "valueMap": [{ "key": "0", "valueString": "en" }]
-            },
-            {
-              "key": "mcSingleCheckbox",
-              "valueMap": [{ "key": "0", "valueString": "pro" }]
-            },
-            {
-              "key": "mcMultiChip",
-              "valueMap": [
-                { "key": "0", "valueString": "mon" },
-                { "key": "1", "valueString": "wed" },
-                { "key": "2", "valueString": "fri" }
-              ]
-            },
-            {
-              "key": "mcMultiCheckbox",
-              "valueMap": [
-                { "key": "0", "valueString": "design" },
-                { "key": "1", "valueString": "frontend" }
-              ]
-            },
-            {
-              "key": "tags",
-              "valueMap": [
-                { "key": "0", "valueString": "TypeScript" },
-                { "key": "1", "valueString": "A2UI" }
-              ]
-            },
-            {
-              "key": "listItems",
-              "valueMap": [
-                { "key": "0", "valueMap": [{ "key": "label", "valueString": "Dynamic list item 1" }] },
-                { "key": "1", "valueMap": [{ "key": "label", "valueString": "Dynamic list item 2" }] },
-                { "key": "2", "valueMap": [{ "key": "label", "valueString": "Dynamic list item 3" }] }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "beginRendering": {
-      "surfaceId": "main",
-      "root": "root",
-      "catalogId": "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json"
     }
   }
 ]

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/dashboard.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/dashboard.ts
@@ -2,268 +2,279 @@
 // SAMPLE: Dashboard - Stats and metrics layout
 // ============================================================================
 export const dashboardSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: {
-            Column: {
-              children: {
-                explicitList: ["dashboard-header", "stats-row", "divider", "details-section"],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "main",
+        value: {
+          stats: {
+            users: "12,847",
+            revenue: "$84,230",
+            orders: "1,429",
+          },
+        },
+      },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: [
+              "dashboard-header",
+              "stats-row",
+              "divider",
+              "details-section",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "dashboard-header",
+            component: "Row",
+            children: [
+              "header-text",
+              "refresh-btn",
+            ],
+            justify: "spaceBetween",
+            align: "center",
+          },
+          {
+            id: "header-text",
+            component: "Text",
+            text: "Analytics Dashboard",
+            variant: "h2",
+          },
+          {
+            id: "refresh-btn",
+            component: "Button",
+            child: "refresh-text",
+            action: {
+              event: {
+                name: "refresh_dashboard",
               },
-              distribution: "start",
-              alignment: "stretch",
             },
+            variant: "default",
           },
-        },
-        {
-          id: "dashboard-header",
-          component: {
-            Row: {
-              children: { explicitList: ["header-text", "refresh-btn"] },
-              distribution: "spaceBetween",
-              alignment: "center",
+          {
+            id: "refresh-text",
+            component: "Text",
+            text: "Refresh",
+            variant: "body",
+          },
+          {
+            id: "stats-row",
+            component: "Row",
+            children: [
+              "stat-card-1",
+              "stat-card-2",
+              "stat-card-3",
+            ],
+            justify: "spaceEvenly",
+            align: "stretch",
+          },
+          {
+            id: "stat-card-1",
+            component: "Card",
+            child: "stat-1-content",
+          },
+          {
+            id: "stat-1-content",
+            component: "Column",
+            children: [
+              "stat-1-label",
+              "stat-1-value",
+              "stat-1-change",
+            ],
+            justify: "center",
+            align: "center",
+          },
+          {
+            id: "stat-1-label",
+            component: "Text",
+            text: "Total Users",
+            variant: "caption",
+          },
+          {
+            id: "stat-1-value",
+            component: "Text",
+            text: {
+              path: "/stats/users",
             },
+            variant: "h1",
           },
-        },
-        {
-          id: "header-text",
-          component: {
-            Text: {
-              text: { literalString: "Analytics Dashboard" },
-              usageHint: "h2",
+          {
+            id: "stat-1-change",
+            component: "Text",
+            text: "+12.5% from last month",
+            variant: "caption",
+          },
+          {
+            id: "stat-card-2",
+            component: "Card",
+            child: "stat-2-content",
+          },
+          {
+            id: "stat-2-content",
+            component: "Column",
+            children: [
+              "stat-2-label",
+              "stat-2-value",
+              "stat-2-change",
+            ],
+            justify: "center",
+            align: "center",
+          },
+          {
+            id: "stat-2-label",
+            component: "Text",
+            text: "Revenue",
+            variant: "caption",
+          },
+          {
+            id: "stat-2-value",
+            component: "Text",
+            text: {
+              path: "/stats/revenue",
             },
+            variant: "h1",
           },
-        },
-        {
-          id: "refresh-btn",
-          component: {
-            Button: {
-              child: "refresh-text",
-              action: { name: "refresh_dashboard", context: [] },
-              primary: false,
+          {
+            id: "stat-2-change",
+            component: "Text",
+            text: "+8.2% from last month",
+            variant: "caption",
+          },
+          {
+            id: "stat-card-3",
+            component: "Card",
+            child: "stat-3-content",
+          },
+          {
+            id: "stat-3-content",
+            component: "Column",
+            children: [
+              "stat-3-label",
+              "stat-3-value",
+              "stat-3-change",
+            ],
+            justify: "center",
+            align: "center",
+          },
+          {
+            id: "stat-3-label",
+            component: "Text",
+            text: "Orders",
+            variant: "caption",
+          },
+          {
+            id: "stat-3-value",
+            component: "Text",
+            text: {
+              path: "/stats/orders",
             },
+            variant: "h1",
           },
-        },
-        {
-          id: "refresh-text",
-          component: {
-            Text: { text: { literalString: "Refresh" }, usageHint: "body" },
+          {
+            id: "stat-3-change",
+            component: "Text",
+            text: "+23.1% from last month",
+            variant: "caption",
           },
-        },
-        {
-          id: "stats-row",
-          component: {
-            Row: {
-              children: { explicitList: ["stat-card-1", "stat-card-2", "stat-card-3"] },
-              distribution: "spaceEvenly",
-              alignment: "stretch",
+          {
+            id: "divider",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "details-section",
+            component: "Column",
+            children: [
+              "details-header",
+              "details-row",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "details-header",
+            component: "Text",
+            text: "Quick Actions",
+            variant: "h4",
+          },
+          {
+            id: "details-row",
+            component: "Row",
+            children: [
+              "action-1",
+              "action-2",
+              "action-3",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "action-1",
+            component: "Button",
+            child: "action-1-text",
+            action: {
+              event: {
+                name: "view_reports",
+              },
             },
+            variant: "primary",
           },
-        },
-        {
-          id: "stat-card-1",
-          component: { Card: { child: "stat-1-content" } },
-        },
-        {
-          id: "stat-1-content",
-          component: {
-            Column: {
-              children: { explicitList: ["stat-1-label", "stat-1-value", "stat-1-change"] },
-              distribution: "center",
-              alignment: "center",
+          {
+            id: "action-1-text",
+            component: "Text",
+            text: "View Reports",
+            variant: "body",
+          },
+          {
+            id: "action-2",
+            component: "Button",
+            child: "action-2-text",
+            action: {
+              event: {
+                name: "export_data",
+              },
             },
+            variant: "default",
           },
-        },
-        {
-          id: "stat-1-label",
-          component: {
-            Text: { text: { literalString: "Total Users" }, usageHint: "caption" },
+          {
+            id: "action-2-text",
+            component: "Text",
+            text: "Export Data",
+            variant: "body",
           },
-        },
-        {
-          id: "stat-1-value",
-          component: {
-            Text: { text: { path: "/stats/users" }, usageHint: "h1" },
-          },
-        },
-        {
-          id: "stat-1-change",
-          component: {
-            Text: {
-              text: { literalString: "+12.5% from last month" },
-              usageHint: "caption",
+          {
+            id: "action-3",
+            component: "Button",
+            child: "action-3-text",
+            action: {
+              event: {
+                name: "settings",
+              },
             },
+            variant: "default",
           },
-        },
-        {
-          id: "stat-card-2",
-          component: { Card: { child: "stat-2-content" } },
-        },
-        {
-          id: "stat-2-content",
-          component: {
-            Column: {
-              children: { explicitList: ["stat-2-label", "stat-2-value", "stat-2-change"] },
-              distribution: "center",
-              alignment: "center",
-            },
+          {
+            id: "action-3-text",
+            component: "Text",
+            text: "Settings",
+            variant: "body",
           },
-        },
-        {
-          id: "stat-2-label",
-          component: {
-            Text: { text: { literalString: "Revenue" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "stat-2-value",
-          component: {
-            Text: { text: { path: "/stats/revenue" }, usageHint: "h1" },
-          },
-        },
-        {
-          id: "stat-2-change",
-          component: {
-            Text: {
-              text: { literalString: "+8.2% from last month" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "stat-card-3",
-          component: { Card: { child: "stat-3-content" } },
-        },
-        {
-          id: "stat-3-content",
-          component: {
-            Column: {
-              children: { explicitList: ["stat-3-label", "stat-3-value", "stat-3-change"] },
-              distribution: "center",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "stat-3-label",
-          component: {
-            Text: { text: { literalString: "Orders" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "stat-3-value",
-          component: {
-            Text: { text: { path: "/stats/orders" }, usageHint: "h1" },
-          },
-        },
-        {
-          id: "stat-3-change",
-          component: {
-            Text: {
-              text: { literalString: "+23.1% from last month" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "divider",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "details-section",
-          component: {
-            Column: {
-              children: { explicitList: ["details-header", "details-row"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "details-header",
-          component: {
-            Text: { text: { literalString: "Quick Actions" }, usageHint: "h4" },
-          },
-        },
-        {
-          id: "details-row",
-          component: {
-            Row: {
-              children: { explicitList: ["action-1", "action-2", "action-3"] },
-              distribution: "start",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "action-1",
-          component: {
-            Button: {
-              child: "action-1-text",
-              action: { name: "view_reports", context: [] },
-              primary: true,
-            },
-          },
-        },
-        {
-          id: "action-1-text",
-          component: {
-            Text: { text: { literalString: "View Reports" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "action-2",
-          component: {
-            Button: {
-              child: "action-2-text",
-              action: { name: "export_data", context: [] },
-              primary: false,
-            },
-          },
-        },
-        {
-          id: "action-2-text",
-          component: {
-            Text: { text: { literalString: "Export Data" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "action-3",
-          component: {
-            Button: {
-              child: "action-3-text",
-              action: { name: "settings", context: [] },
-              primary: false,
-            },
-          },
-        },
-        {
-          id: "action-3-text",
-          component: {
-            Text: { text: { literalString: "Settings" }, usageHint: "body" },
-          },
-        },
-      ],
+        ],
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/stats",
-      contents: [
-        { key: "users", valueString: "12,847" },
-        { key: "revenue", valueString: "$84,230" },
-        { key: "orders", valueString: "1,429" },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
-    },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/deleteSurface.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/deleteSurface.ts
@@ -2,106 +2,95 @@
 // SAMPLE: Delete Surface - Multiple surfaces with deletion
 // ============================================================================
 export const deleteSurfaceSample = [
-  // Main surface
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "main-root",
-          component: { Card: { child: "main-content" } },
-        },
-        {
-          id: "main-content",
-          component: {
-            Column: {
-              children: { explicitList: ["main-header", "main-body"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "main-header",
-          component: {
-            Text: { text: { literalString: "Main Surface" }, usageHint: "h3" },
-          },
-        },
-        {
-          id: "main-body",
-          component: {
-            Text: {
-              text: {
-                literalString: "This surface will remain after the temporary one is deleted.",
-              },
-              usageHint: "body",
-            },
-          },
-        },
-      ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
     },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "main-root",
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Card",
+            child: "main-content",
+          },
+          {
+            id: "main-content",
+            component: "Column",
+            children: [
+              "main-header",
+              "main-body",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "main-header",
+            component: "Text",
+            text: "Main Surface",
+            variant: "h3",
+          },
+          {
+            id: "main-body",
+            component: "Text",
+            text: "This surface will remain after the temporary one is deleted.",
+            variant: "body",
+          },
+        ],
+      },
     },
-  },
-  // Temporary surface
-  {
-    surfaceUpdate: {
-      surfaceId: "temporary",
-      components: [
-        {
-          id: "temp-root",
-          component: { Card: { child: "temp-content" } },
-        },
-        {
-          id: "temp-content",
-          component: {
-            Column: {
-              children: { explicitList: ["temp-header", "temp-body", "temp-countdown"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "temp-header",
-          component: {
-            Text: {
-              text: { literalString: "⏱️ Temporary Surface" },
-              usageHint: "h3",
-            },
-          },
-        },
-        {
-          id: "temp-body",
-          component: {
-            Text: {
-              text: {
-                literalString: "This surface will be automatically deleted in 3 seconds...",
-              },
-              usageHint: "body",
-            },
-          },
-        },
-        {
-          id: "temp-countdown",
-          component: {
-            Text: {
-              text: { literalString: "Watch it disappear! 👀" },
-              usageHint: "caption",
-            },
-          },
-        },
-      ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "temporary",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
     },
-  },
-  {
-    beginRendering: {
-      surfaceId: "temporary",
-      root: "temp-root",
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "temporary",
+        components: [
+          {
+            id: "root",
+            component: "Card",
+            child: "temp-content",
+          },
+          {
+            id: "temp-content",
+            component: "Column",
+            children: [
+              "temp-header",
+              "temp-body",
+              "temp-countdown",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "temp-header",
+            component: "Text",
+            text: "⏱️ Temporary Surface",
+            variant: "h3",
+          },
+          {
+            id: "temp-body",
+            component: "Text",
+            text: "This surface will be automatically deleted in 3 seconds...",
+            variant: "body",
+          },
+          {
+            id: "temp-countdown",
+            component: "Text",
+            text: "Watch it disappear! 👀",
+            variant: "caption",
+          },
+        ],
+      },
     },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/form.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/form.ts
@@ -2,316 +2,312 @@
 // SAMPLE: Form - All input field types
 // ============================================================================
 export const formSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: {
-            Card: { child: "form-content" },
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "main",
+        value: {
+          form: {
+            name: "John Doe",
+            email: "john@example.com",
+            password: "",
+            age: 25,
+            bio: "Software developer passionate about UI/UX.",
+            dob: "1999-01-15",
+            agreeTerms: {
+              value: false,
+              label: "I agree to the Terms of Service",
+            },
+            newsletter: {
+              value: true,
+              label: "Subscribe to newsletter",
+            },
           },
         },
-        {
-          id: "form-content",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "form-header",
-                  "form-description",
-                  "divider-top",
-                  "name-field",
-                  "email-field",
-                  "password-field",
-                  "age-field",
-                  "bio-field",
-                  "date-field",
-                  "single-select-label",
-                  "single-select-field",
-                  "multi-select-label",
-                  "multi-select-field",
-                  "divider-mid",
-                  "checkbox-section",
-                  "divider-bottom",
-                  "button-row",
-                ],
+      },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Card",
+            child: "form-content",
+          },
+          {
+            id: "form-content",
+            component: "Column",
+            children: [
+              "form-header",
+              "form-description",
+              "divider-top",
+              "name-field",
+              "email-field",
+              "password-field",
+              "age-field",
+              "bio-field",
+              "date-field",
+              "single-select-field",
+              "multi-select-field",
+              "divider-mid",
+              "checkbox-section",
+              "divider-bottom",
+              "button-row",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "form-header",
+            component: "Text",
+            text: "Registration Form",
+            variant: "h2",
+          },
+          {
+            id: "form-description",
+            component: "Text",
+            text: "Complete all fields to create your account",
+            variant: "caption",
+          },
+          {
+            id: "divider-top",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "name-field",
+            component: "TextField",
+            label: "Full Name",
+            value: {
+              path: "/form/name",
+            },
+            variant: "shortText",
+          },
+          {
+            id: "email-field",
+            component: "TextField",
+            label: "Email Address",
+            validationRegexp: "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$",
+            value: {
+              path: "/form/email",
+            },
+            variant: "shortText",
+          },
+          {
+            id: "password-field",
+            component: "TextField",
+            label: "Password",
+            value: {
+              path: "/form/password",
+            },
+            variant: "obscured",
+          },
+          {
+            id: "age-field",
+            component: "TextField",
+            label: "Age",
+            value: {
+              path: "/form/age",
+            },
+            variant: "number",
+          },
+          {
+            id: "bio-field",
+            component: "TextField",
+            label: "Bio (Optional)",
+            value: {
+              path: "/form/bio",
+            },
+            variant: "longText",
+          },
+          {
+            id: "date-field",
+            component: "DateTimeInput",
+            label: "Date of Birth",
+            value: {
+              path: "/form/dob",
+            },
+            enableDate: true,
+            enableTime: false,
+          },
+          {
+            id: "single-select-field",
+            component: "ChoicePicker",
+            label: "Account Plan",
+            options: [
+              {
+                value: "free",
+                label: "Free",
               },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "form-header",
-          component: {
-            Text: {
-              text: { literalString: "Registration Form" },
-              usageHint: "h2",
-            },
-          },
-        },
-        {
-          id: "form-description",
-          component: {
-            Text: {
-              text: {
-                literalString: "Complete all fields to create your account",
+              {
+                value: "pro",
+                label: "Pro",
               },
-              usageHint: "caption",
+              {
+                value: "enterprise",
+                label: "Enterprise",
+              },
+            ],
+            value: {
+              path: "/form/plan",
+            },
+            displayStyle: "chips",
+            variant: "mutuallyExclusive",
+          },
+          {
+            id: "multi-select-field",
+            component: "ChoicePicker",
+            label: "Areas of Interest",
+            options: [
+              {
+                value: "frontend",
+                label: "Frontend",
+              },
+              {
+                value: "backend",
+                label: "Backend",
+              },
+              {
+                value: "devops",
+                label: "DevOps",
+              },
+              {
+                value: "design",
+                label: "Design",
+              },
+            ],
+            value: {
+              path: "/form/interests",
+            },
+            displayStyle: "chips",
+            variant: "multipleSelection",
+          },
+          {
+            id: "divider-mid",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "checkbox-section",
+            component: "Column",
+            children: [
+              "terms-checkbox",
+              "newsletter-checkbox",
+            ],
+            justify: "start",
+            align: "start",
+          },
+          {
+            id: "terms-checkbox",
+            component: "CheckBox",
+            label: {
+              path: "/form/agreeTerms/label",
+            },
+            value: {
+              path: "/form/agreeTerms/value",
             },
           },
-        },
-        {
-          id: "divider-top",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "name-field",
-          component: {
-            TextField: {
-              label: { literalString: "Full Name" },
-              text: { path: "/form/name" },
-              textFieldType: "shortText",
+          {
+            id: "newsletter-checkbox",
+            component: "CheckBox",
+            label: {
+              path: "/form/newsletter/label",
+            },
+            value: {
+              path: "/form/newsletter/value",
             },
           },
-        },
-        {
-          id: "email-field",
-          component: {
-            TextField: {
-              label: { literalString: "Email Address" },
-              text: { path: "/form/email" },
-              textFieldType: "shortText",
-              validationRegexp: "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$",
+          {
+            id: "divider-bottom",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "button-row",
+            component: "Row",
+            children: [
+              "cancel-btn",
+              "submit-btn",
+            ],
+            justify: "end",
+            align: "center",
+          },
+          {
+            id: "cancel-btn",
+            component: "Button",
+            child: "cancel-text",
+            action: {
+              event: {
+                name: "form_cancel",
+              },
             },
+            variant: "default",
           },
-        },
-        {
-          id: "password-field",
-          component: {
-            TextField: {
-              label: { literalString: "Password" },
-              text: { path: "/form/password" },
-              textFieldType: "obscured",
-            },
+          {
+            id: "cancel-text",
+            component: "Text",
+            text: "Cancel",
+            variant: "body",
           },
-        },
-        {
-          id: "age-field",
-          component: {
-            TextField: {
-              label: { literalString: "Age" },
-              text: { path: "/form/age" },
-              textFieldType: "number",
-            },
-          },
-        },
-        {
-          id: "bio-field",
-          component: {
-            TextField: {
-              label: { literalString: "Bio (Optional)" },
-              text: { path: "/form/bio" },
-              textFieldType: "longText",
-            },
-          },
-        },
-        {
-          id: "date-field",
-          component: {
-            TextField: {
-              label: { literalString: "Date of Birth" },
-              text: { path: "/form/dob" },
-              textFieldType: "date",
-            },
-          },
-        },
-        {
-          id: "single-select-label",
-          component: {
-            Text: {
-              text: { literalString: "Account Plan" },
-              usageHint: "h4",
-            },
-          },
-        },
-        {
-          id: "single-select-field",
-          component: {
-            MultipleChoice: {
-              selections: { path: "/form/plan" },
-              type: "chips",
-              maxAllowedSelections: 1,
-              options: [
-                { value: "free", label: { literalString: "Free" } },
-                { value: "pro", label: { literalString: "Pro" } },
-                { value: "enterprise", label: { literalString: "Enterprise" } },
-              ],
-            },
-          },
-        },
-        {
-          id: "multi-select-label",
-          component: {
-            Text: {
-              text: { literalString: "Areas of Interest" },
-              usageHint: "h4",
-            },
-          },
-        },
-        {
-          id: "multi-select-field",
-          component: {
-            MultipleChoice: {
-              selections: { path: "/form/interests" },
-              type: "chips",
-              maxAllowedSelections: 4,
-              options: [
-                { value: "frontend", label: { literalString: "Frontend" } },
-                { value: "backend", label: { literalString: "Backend" } },
-                { value: "devops", label: { literalString: "DevOps" } },
-                { value: "design", label: { literalString: "Design" } },
-              ],
-            },
-          },
-        },
-        {
-          id: "divider-mid",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "checkbox-section",
-          component: {
-            Column: {
-              children: { explicitList: ["terms-checkbox", "newsletter-checkbox"] },
-              distribution: "start",
-              alignment: "start",
-            },
-          },
-        },
-        {
-          id: "terms-checkbox",
-          component: {
-            CheckBox: {
-              label: { path: "/form/agreeTerms/label" },
-              value: { path: "/form/agreeTerms/value" },
-            },
-          },
-        },
-        {
-          id: "newsletter-checkbox",
-          component: {
-            CheckBox: {
-              label: { path: "/form/newsletter/label" },
-              value: { path: "/form/newsletter/value" },
-            },
-          },
-        },
-        {
-          id: "divider-bottom",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "button-row",
-          component: {
-            Row: {
-              children: { explicitList: ["cancel-btn", "submit-btn"] },
-              distribution: "end",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "cancel-btn",
-          component: {
-            Button: {
-              child: "cancel-text",
-              action: { name: "form_cancel", context: [] },
-              primary: false,
-            },
-          },
-        },
-        {
-          id: "cancel-text",
-          component: {
-            Text: { text: { literalString: "Cancel" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "submit-btn",
-          component: {
-            Button: {
-              child: "submit-text",
-              action: {
+          {
+            id: "submit-btn",
+            component: "Button",
+            child: "submit-text",
+            action: {
+              event: {
                 name: "form_submit",
-                context: [
-                  { key: "name", value: { path: "/form/name" } },
-                  { key: "email", value: { path: "/form/email" } },
-                  { key: "password", value: { path: "/form/password" } },
-                  { key: "age", value: { path: "/form/age" } },
-                  { key: "bio", value: { path: "/form/bio" } },
-                  { key: "dob", value: { path: "/form/dob" } },
-                  { key: "plan", value: { path: "/form/plan" } },
-                  { key: "interests", value: { path: "/form/interests" } },
-                  { key: "agreeTerms", value: { path: "/form/agreeTerms/value" } },
-                  { key: "newsletter", value: { path: "/form/newsletter/value" } },
-                ],
+                context: {
+                  name: {
+                    path: "/form/name",
+                  },
+                  email: {
+                    path: "/form/email",
+                  },
+                  password: {
+                    path: "/form/password",
+                  },
+                  age: {
+                    path: "/form/age",
+                  },
+                  bio: {
+                    path: "/form/bio",
+                  },
+                  dob: {
+                    path: "/form/dob",
+                  },
+                  plan: {
+                    path: "/form/plan",
+                  },
+                  interests: {
+                    path: "/form/interests",
+                  },
+                  agreeTerms: {
+                    path: "/form/agreeTerms/value",
+                  },
+                  newsletter: {
+                    path: "/form/newsletter/value",
+                  },
+                },
               },
-              primary: true,
             },
+            variant: "primary",
           },
-        },
-        {
-          id: "submit-text",
-          component: {
-            Text: {
-              text: { literalString: "Create Account" },
-              usageHint: "body",
-            },
+          {
+            id: "submit-text",
+            component: "Text",
+            text: "Create Account",
+            variant: "body",
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/form",
-      contents: [
-        { key: "name", valueString: "John Doe" },
-        { key: "email", valueString: "john@example.com" },
-        { key: "password", valueString: "" },
-        { key: "age", valueNumber: 25 },
-        { key: "bio", valueString: "Software developer passionate about UI/UX." },
-        { key: "dob", valueString: "1999-01-15" },
-      ],
-    },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/form/agreeTerms",
-      contents: [
-        { key: "value", valueBoolean: false },
-        { key: "label", valueString: "I agree to the Terms of Service" },
-      ],
-    },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/form/newsletter",
-      contents: [
-        { key: "value", valueBoolean: true },
-        { key: "label", valueString: "Subscribe to newsletter" },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
-    },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/gallery.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/gallery.ts
@@ -2,219 +2,189 @@
 // SAMPLE: Gallery - Image showcase with all fit types
 // ============================================================================
 export const gallerySample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "gallery-header",
-                  "hero-section",
-                  "divider-1",
-                  "thumbnails-section",
-                  "divider-2",
-                  "avatars-section",
-                ],
-              },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "gallery-header",
-          component: {
-            Text: {
-              text: { literalString: "Image Gallery" },
-              usageHint: "h2",
-            },
-          },
-        },
-        {
-          id: "hero-section",
-          component: {
-            Column: {
-              children: { explicitList: ["hero-label", "hero-image"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "hero-label",
-          component: {
-            Text: {
-              text: { literalString: "Hero Image (cover fit)" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "hero-image",
-          component: {
-            Image: {
-              url: { path: "/gallery/heroUrl" },
-              fit: "cover",
-              usageHint: "largeFeature",
-            },
-          },
-        },
-        {
-          id: "divider-1",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "thumbnails-section",
-          component: {
-            Column: {
-              children: { explicitList: ["thumbnails-label", "thumbnails-row"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "thumbnails-label",
-          component: {
-            Text: {
-              text: { literalString: "Thumbnails (contain fit)" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "thumbnails-row",
-          component: {
-            Row: {
-              children: { explicitList: ["thumb-1", "thumb-2", "thumb-3", "thumb-4"] },
-              distribution: "spaceEvenly",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "thumb-1",
-          component: {
-            Image: {
-              url: { literalString: "https://picsum.photos/seed/a2ui1/150/150" },
-              fit: "contain",
-              usageHint: "smallFeature",
-            },
-          },
-        },
-        {
-          id: "thumb-2",
-          component: {
-            Image: {
-              url: { literalString: "https://picsum.photos/seed/a2ui2/150/150" },
-              fit: "contain",
-              usageHint: "smallFeature",
-            },
-          },
-        },
-        {
-          id: "thumb-3",
-          component: {
-            Image: {
-              url: { literalString: "https://picsum.photos/seed/a2ui3/150/150" },
-              fit: "contain",
-              usageHint: "smallFeature",
-            },
-          },
-        },
-        {
-          id: "thumb-4",
-          component: {
-            Image: {
-              url: { literalString: "https://picsum.photos/seed/a2ui4/150/150" },
-              fit: "contain",
-              usageHint: "smallFeature",
-            },
-          },
-        },
-        {
-          id: "divider-2",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "avatars-section",
-          component: {
-            Column: {
-              children: { explicitList: ["avatars-label", "avatars-row"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "avatars-label",
-          component: {
-            Text: {
-              text: { literalString: "Avatars (avatar hint)" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "avatars-row",
-          component: {
-            Row: {
-              children: { explicitList: ["avatar-1", "avatar-2", "avatar-3"] },
-              distribution: "start",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "avatar-1",
-          component: {
-            Image: {
-              url: { literalString: "https://i.pravatar.cc/100?img=1" },
-              fit: "cover",
-              usageHint: "avatar",
-            },
-          },
-        },
-        {
-          id: "avatar-2",
-          component: {
-            Image: {
-              url: { literalString: "https://i.pravatar.cc/100?img=2" },
-              fit: "cover",
-              usageHint: "avatar",
-            },
-          },
-        },
-        {
-          id: "avatar-3",
-          component: {
-            Image: {
-              url: { literalString: "https://i.pravatar.cc/100?img=3" },
-              fit: "cover",
-              usageHint: "avatar",
-            },
-          },
-        },
-      ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/gallery",
-      contents: [
-        { key: "heroUrl", valueString: "https://picsum.photos/seed/hero/800/400" },
-      ],
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "main",
+        value: {
+          gallery: {
+            heroUrl: "https://picsum.photos/seed/hero/800/400",
+          },
+        },
+      },
     },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: [
+              "gallery-header",
+              "hero-section",
+              "divider-1",
+              "thumbnails-section",
+              "divider-2",
+              "avatars-section",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "gallery-header",
+            component: "Text",
+            text: "Image Gallery",
+            variant: "h2",
+          },
+          {
+            id: "hero-section",
+            component: "Column",
+            children: [
+              "hero-label",
+              "hero-image",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "hero-label",
+            component: "Text",
+            text: "Hero Image (cover fit)",
+            variant: "caption",
+          },
+          {
+            id: "hero-image",
+            component: "Image",
+            url: {
+              path: "/gallery/heroUrl",
+            },
+            fit: "cover",
+            variant: "largeFeature",
+          },
+          {
+            id: "divider-1",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "thumbnails-section",
+            component: "Column",
+            children: [
+              "thumbnails-label",
+              "thumbnails-row",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "thumbnails-label",
+            component: "Text",
+            text: "Thumbnails (contain fit)",
+            variant: "caption",
+          },
+          {
+            id: "thumbnails-row",
+            component: "Row",
+            children: [
+              "thumb-1",
+              "thumb-2",
+              "thumb-3",
+              "thumb-4",
+            ],
+            justify: "spaceEvenly",
+            align: "center",
+          },
+          {
+            id: "thumb-1",
+            component: "Image",
+            url: "https://picsum.photos/seed/a2ui1/150/150",
+            fit: "contain",
+            variant: "smallFeature",
+          },
+          {
+            id: "thumb-2",
+            component: "Image",
+            url: "https://picsum.photos/seed/a2ui2/150/150",
+            fit: "contain",
+            variant: "smallFeature",
+          },
+          {
+            id: "thumb-3",
+            component: "Image",
+            url: "https://picsum.photos/seed/a2ui3/150/150",
+            fit: "contain",
+            variant: "smallFeature",
+          },
+          {
+            id: "thumb-4",
+            component: "Image",
+            url: "https://picsum.photos/seed/a2ui4/150/150",
+            fit: "contain",
+            variant: "smallFeature",
+          },
+          {
+            id: "divider-2",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "avatars-section",
+            component: "Column",
+            children: [
+              "avatars-label",
+              "avatars-row",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "avatars-label",
+            component: "Text",
+            text: "Avatars (avatar hint)",
+            variant: "caption",
+          },
+          {
+            id: "avatars-row",
+            component: "Row",
+            children: [
+              "avatar-1",
+              "avatar-2",
+              "avatar-3",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "avatar-1",
+            component: "Image",
+            url: "https://i.pravatar.cc/100?img=1",
+            fit: "cover",
+            variant: "avatar",
+          },
+          {
+            id: "avatar-2",
+            component: "Image",
+            url: "https://i.pravatar.cc/100?img=2",
+            fit: "cover",
+            variant: "avatar",
+          },
+          {
+            id: "avatar-3",
+            component: "Image",
+            url: "https://i.pravatar.cc/100?img=3",
+            fit: "cover",
+            variant: "avatar",
+          },
+        ],
+      },
     },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/greetings.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/greetings.ts
@@ -3,151 +3,115 @@
 // ============================================================================
 export const helloSample = [
   {
-    surfaceUpdate: {
+    version: "v0.9",
+    createSurface: {
+      surfaceId: "main",
+      catalogId:
+        "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+    },
+  },
+  {
+    version: "v0.9",
+    updateDataModel: {
+      surfaceId: "main",
+      value: {
+        commands: [
+          {
+            command: "• 'typography' - **Text styles**",
+          },
+          {
+            command: "• 'form' - _Input fields_",
+          },
+          {
+            command: "• 'gallery' - Images",
+          },
+          {
+            command: "• 'dashboard' - Stats layout",
+          },
+          {
+            command: "• 'profile' - User profile",
+          },
+          {
+            command: "• 'settings' - Config panel",
+          },
+          {
+            command: "• 'hitl' - Approval flow",
+          },
+          {
+            command: "• 'product' - Product card",
+          },
+          {
+            command: "• 'layout' - Grid layouts",
+          },
+          {
+            command: "• 'delete-surface' - Surface deletion (temporary)",
+          },
+          {
+            command: "• 'components' - Full GLChat catalog (all 20 components)",
+          },
+        ],
+      },
+    },
+  },
+  {
+    version: "v0.9",
+    updateComponents: {
       surfaceId: "main",
       components: [
         {
           id: "root",
-          component: {
-            Card: { child: "content" },
-          },
+          component: "Card",
+          child: "content",
         },
         {
           id: "content",
-          component: {
-            Column: {
-              children: {
-                explicitList: ["header", "description", "command-list", "divider", "footer"],
-              },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
+          component: "Column",
+          children: ["header", "description", "command-list", "divider", "footer"],
+          justify: "start",
+          align: "stretch",
         },
         {
           id: "header",
-          component: {
-            Text: {
-              text: { literalString: "Hello! 👋" },
-              usageHint: "h2",
-            },
-          },
+          component: "Text",
+          text: "Hello! 👋",
+          variant: "h2",
         },
         {
           id: "description",
-          component: {
-            Text: {
-              text: {
-                literalString: "Welcome to A2UI! Try these commands:",
-              },
-              usageHint: "body",
-            },
-          },
+          component: "Text",
+          text: "Welcome to A2UI! Try these commands:",
+          variant: "body",
         },
         {
           id: "command-list",
-          component: {
-            List: {
-              children: {
-                template: {
-                  componentId: "command-item",
-                  dataBinding: "/commands",
-                },
-              },
-              direction: "vertical",
-              alignment: "start",
-            },
+          component: "List",
+          children: {
+            componentId: "command-item",
+            path: "/commands",
           },
+          direction: "vertical",
+          align: "start",
         },
         {
           id: "command-item",
-          component: {
-            Text: {
-              text: { path: "command" },
-              usageHint: "body",
-            },
+          component: "Text",
+          text: {
+            path: "command",
           },
+          variant: "body",
         },
         {
           id: "divider",
-          component: {
-            Divider: { axis: "horizontal" },
-          },
+          component: "Divider",
+          axis: "horizontal",
         },
         {
           id: "footer",
-          component: {
-            Text: {
-              text: {
-                literalString: "Type any keyword above to see the demo!",
-              },
-              usageHint: "caption",
-            },
-          },
+          component: "Text",
+          text: "Type any keyword above to see the demo!",
+          variant: "caption",
         },
       ],
-    },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/commands",
-      contents: [
-        {
-          key: "0",
-          valueMap: [{ key: "command", valueString: "• 'typography' - Text styles" }],
-        },
-        {
-          key: "1",
-          valueMap: [{ key: "command", valueString: "• 'form' - Input fields" }],
-        },
-        {
-          key: "2",
-          valueMap: [{ key: "command", valueString: "• 'gallery' - Images" }],
-        },
-        {
-          key: "3",
-          valueMap: [{ key: "command", valueString: "• 'dashboard' - Stats layout" }],
-        },
-        {
-          key: "4",
-          valueMap: [{ key: "command", valueString: "• 'profile' - User profile" }],
-        },
-        {
-          key: "5",
-          valueMap: [{ key: "command", valueString: "• 'settings' - Config panel" }],
-        },
-        {
-          key: "6",
-          valueMap: [{ key: "command", valueString: "• 'hitl' - Approval flow" }],
-        },
-        {
-          key: "7",
-          valueMap: [{ key: "command", valueString: "• 'product' - Product card" }],
-        },
-        {
-          key: "8",
-          valueMap: [{ key: "command", valueString: "• 'layout' - Grid layouts" }],
-        },
-        {
-          key: "9",
-          valueMap: [
-            { key: "command", valueString: "• 'delete-surface' - Surface deletion (temporary)" },
-          ],
-        },
-        {
-          key: "11",
-          valueMap: [
-            { key: "command", valueString: "• 'components' - Full GLChat catalog (all 22 components)" },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
     },
   },
 ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/hitl.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/hitl.ts
@@ -2,235 +2,237 @@
 // SAMPLE: HITL - Human-in-the-loop approval workflow
 // ============================================================================
 export const hitlSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "header",
-      components: [
-        {
-          id: "root",
-          component: {
-            Row: {
-              children: { explicitList: ["title", "icon"] },
-              distribution: "start",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "title",
-          component: {
-            Text: { text: { path: "/header/title" }, usageHint: "h2" },
-          },
-        },
-        {
-          id: "icon",
-          component: {
-            Text: { text: { path: "/header/icon" }, usageHint: "h2" },
-          },
-        },
-      ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "header",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "header",
-      contents: [
-        {
-          key: "header",
-          valueMap: [
-            { key: "title", valueString: "Approval Required" },
-            { key: "icon", valueString: "⚠️" },
-          ],
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "header",
+        value: {
+          header: {
+            title: "Approval Required",
+            icon: "⚠️",
+          },
         },
-      ],
+      },
     },
-  },
-  {
-    beginRendering: {
-      surfaceId: "header",
-      root: "root",
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "header",
+        components: [
+          {
+            id: "root",
+            component: "Row",
+            children: [
+              "title",
+              "icon",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "title",
+            component: "Text",
+            text: {
+              path: "/header/title",
+            },
+            variant: "h2",
+          },
+          {
+            id: "icon",
+            component: "Text",
+            text: {
+              path: "/header/icon",
+            },
+            variant: "h2",
+          },
+        ],
+      },
     },
-  },
-  {
-    surfaceUpdate: {
-      surfaceId: "hitl",
-      components: [
-        {
-          id: "root",
-          component: {
-            Column: {
-              children: { explicitList: ["action-card"] },
-              distribution: "start",
-              alignment: "stretch",
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "hitl",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "hitl",
+        value: {
+          hitl: {
+            requestId: "REQ-2024-00847",
+            expiresAt: "2026-03-26T10:10:00Z",
+          },
+        },
+      },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "hitl",
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: [
+              "action-card",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "hitl-header",
+            component: "Row",
+            children: [
+              "header-icon",
+              "header-text",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "header-icon",
+            component: "Text",
+            text: {
+              path: "/hitl/icon",
+            },
+            variant: "h2",
+          },
+          {
+            id: "header-text",
+            component: "Text",
+            text: {
+              path: "/hitl/title",
+            },
+            variant: "h2",
+          },
+          {
+            id: "action-card",
+            component: "Card",
+            child: "action-content",
+          },
+          {
+            id: "action-content",
+            component: "Column",
+            children: [
+              "action-label-row",
+              "action-buttons",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "action-label-row",
+            component: "Row",
+            children: [
+              "action-label",
+              "hitl-timeout",
+            ],
+            justify: "start",
+            align: "end",
+          },
+          {
+            id: "action-label",
+            component: "Text",
+            text: "Please review and take action:",
+            variant: "body",
+          },
+          {
+            id: "hitl-timeout",
+            component: "Timeout",
+            targetTimeUtc: {
+              path: "/hitl/expiresAt",
             },
           },
-        },
-        {
-          id: "hitl-header",
-          component: {
-            Row: {
-              children: { explicitList: ["header-icon", "header-text"] },
-              distribution: "start",
-              alignment: "center",
-            },
+          {
+            id: "action-buttons",
+            component: "Row",
+            children: [
+              "approve-btn",
+              "reject-btn",
+              "skip-btn",
+            ],
+            justify: "start",
+            align: "start",
           },
-        },
-        {
-          id: "header-icon",
-          component: {
-            Text: { text: { path: "/hitl/icon" }, usageHint: "h2" },
-          },
-        },
-        {
-          id: "header-text",
-          component: {
-            Text: {
-              text: { path: "/hitl/title" },
-              usageHint: "h2",
-            },
-          },
-        },
-        // Action card
-        {
-          id: "action-card",
-          component: { Card: { child: "action-content" } },
-        },
-        {
-          id: "action-content",
-          component: {
-            Column: {
-              children: { explicitList: ["action-label-row", "action-buttons"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "action-label-row",
-          component: {
-            Row: {
-              children: { explicitList: ["action-label", "hitl-timeout"] },
-              distribution: "start",
-              alignment: "end",
-            },
-          },
-        },
-        {
-          id: "action-label",
-          component: {
-            Text: {
-              text: { literalString: "Please review and take action:" },
-              usageHint: "body",
-            },
-          },
-        },
-        {
-          id: "hitl-timeout",
-          component: {
-            Timeout: {
-              targetTimeUtc: { path: "/hitl/expiresAt" },
-            },
-          },
-        },
-        {
-          id: "action-buttons",
-          component: {
-            Row: {
-              children: { explicitList: ["approve-btn", "reject-btn", "skip-btn"] },
-              distribution: "start",
-              alignment: "start",
-            },
-          },
-        },
-        {
-          id: "approve-btn",
-          component: {
-            Button: {
-              child: "approve-text",
-              action: {
+          {
+            id: "approve-btn",
+            component: "Button",
+            child: "approve-text",
+            action: {
+              event: {
                 name: "hitl_decision",
-                context: [
-                  { key: "decision", value: { literalString: "approved" } },
-                  { key: "requestId", value: { path: "/hitl/requestId" } },
-                ],
+                context: {
+                  decision: "approved",
+                  requestId: {
+                    path: "/hitl/requestId",
+                  },
+                },
               },
-              primary: true,
             },
+            variant: "primary",
           },
-        },
-        {
-          id: "approve-text",
-          component: {
-            Text: { text: { literalString: "✓ Approve" }, usageHint: "body" },
+          {
+            id: "approve-text",
+            component: "Text",
+            text: "✓ Approve",
+            variant: "body",
           },
-        },
-        {
-          id: "reject-btn",
-          component: {
-            DestructiveButton: {
-              child: "reject-text",
-              action: {
+          {
+            id: "reject-btn",
+            component: "Button",
+            child: "reject-text",
+            action: {
+              event: {
                 name: "hitl_decision",
-                context: [
-                  { key: "decision", value: { literalString: "rejected" } },
-                  { key: "requestId", value: { path: "/hitl/requestId" } },
-                ],
+                context: {
+                  decision: "rejected",
+                  requestId: {
+                    path: "/hitl/requestId",
+                  },
+                },
               },
             },
+            variant: "destructive",
           },
-        },
-        {
-          id: "reject-text",
-          component: {
-            Text: { text: { literalString: "✗ Reject" }, usageHint: "body" },
+          {
+            id: "reject-text",
+            component: "Text",
+            text: "✗ Reject",
+            variant: "body",
           },
-        },
-        {
-          id: "skip-btn",
-          component: {
-            Button: {
-              child: "skip-text",
-              action: {
+          {
+            id: "skip-btn",
+            component: "Button",
+            child: "skip-text",
+            action: {
+              event: {
                 name: "hitl_decision",
-                context: [
-                  { key: "decision", value: { literalString: "skipped" } },
-                  { key: "requestId", value: { path: "/hitl/requestId" } },
-                ],
+                context: {
+                  decision: "skipped",
+                  requestId: {
+                    path: "/hitl/requestId",
+                  },
+                },
               },
-              primary: false,
             },
+            variant: "default",
           },
-        },
-        {
-          id: "skip-text",
-          component: {
-            Text: { text: { literalString: "Skip" }, usageHint: "body" },
+          {
+            id: "skip-text",
+            component: "Text",
+            text: "Skip",
+            variant: "body",
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "hitl",
-      contents: [
-        {
-          key: "hitl",
-          valueMap: [
-            { key: "requestId", valueString: "REQ-2024-00847" },
-            {
-              key: "expiresAt",
-              valueString: "2026-03-26T10:10:00Z",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "hitl",
-      root: "root",
-    },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/layout.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/layout.ts
@@ -1,415 +1,601 @@
 // ============================================================================
-// SAMPLE: Layout - Demonstrating Row/Column distribution and alignment
+// SAMPLE: Layout - Grid and flex layouts
 // ============================================================================
 export const layoutSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: {
-            Column: {
-              children: { explicitList: ["layout-header", "row-demos", "column-demos"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "layout-header",
-          component: {
-            Text: {
-              text: { literalString: "Layout Examples" },
-              usageHint: "h2",
-            },
-          },
-        },
-        // Row distribution demos
-        {
-          id: "row-demos",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "row-header",
-                  "row-start",
-                  "row-center",
-                  "row-end",
-                  "row-between",
-                  "row-evenly",
-                ],
-              },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "row-header",
-          component: {
-            Text: {
-              text: { literalString: "Row Distribution" },
-              usageHint: "h4",
-            },
-          },
-        },
-        // Row start
-        {
-          id: "row-start",
-          component: {
-            Card: { child: "row-start-content" },
-          },
-        },
-        {
-          id: "row-start-content",
-          component: {
-            Column: {
-              children: { explicitList: ["row-start-label", "row-start-demo"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "row-start-label",
-          component: {
-            Text: {
-              text: { literalString: "distribution: start" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "row-start-demo",
-          component: {
-            Row: {
-              children: { explicitList: ["box-1a", "box-1b", "box-1c"] },
-              distribution: "start",
-              alignment: "center",
-            },
-          },
-        },
-        // Row center
-        {
-          id: "row-center",
-          component: {
-            Card: { child: "row-center-content" },
-          },
-        },
-        {
-          id: "row-center-content",
-          component: {
-            Column: {
-              children: { explicitList: ["row-center-label", "row-center-demo"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "row-center-label",
-          component: {
-            Text: {
-              text: { literalString: "distribution: center" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "row-center-demo",
-          component: {
-            Row: {
-              children: { explicitList: ["box-2a", "box-2b", "box-2c"] },
-              distribution: "center",
-              alignment: "center",
-            },
-          },
-        },
-        // Row end
-        {
-          id: "row-end",
-          component: {
-            Card: { child: "row-end-content" },
-          },
-        },
-        {
-          id: "row-end-content",
-          component: {
-            Column: {
-              children: { explicitList: ["row-end-label", "row-end-demo"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "row-end-label",
-          component: {
-            Text: {
-              text: { literalString: "distribution: end" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "row-end-demo",
-          component: {
-            Row: {
-              children: { explicitList: ["box-3a", "box-3b", "box-3c"] },
-              distribution: "end",
-              alignment: "center",
-            },
-          },
-        },
-        // Row spaceBetween
-        {
-          id: "row-between",
-          component: {
-            Card: { child: "row-between-content" },
-          },
-        },
-        {
-          id: "row-between-content",
-          component: {
-            Column: {
-              children: { explicitList: ["row-between-label", "row-between-demo"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "row-between-label",
-          component: {
-            Text: {
-              text: { literalString: "distribution: spaceBetween" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "row-between-demo",
-          component: {
-            Row: {
-              children: { explicitList: ["box-4a", "box-4b", "box-4c"] },
-              distribution: "spaceBetween",
-              alignment: "center",
-            },
-          },
-        },
-        // Row spaceEvenly
-        {
-          id: "row-evenly",
-          component: {
-            Card: { child: "row-evenly-content" },
-          },
-        },
-        {
-          id: "row-evenly-content",
-          component: {
-            Column: {
-              children: { explicitList: ["row-evenly-label", "row-evenly-demo"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "row-evenly-label",
-          component: {
-            Text: {
-              text: { literalString: "distribution: spaceEvenly" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "row-evenly-demo",
-          component: {
-            Row: {
-              children: { explicitList: ["box-5a", "box-5b", "box-5c"] },
-              distribution: "spaceEvenly",
-              alignment: "center",
-            },
-          },
-        },
-        { id: "box-1a", component: { Button: { child: "box-1a-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-1b", component: { Button: { child: "box-1b-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-1c", component: { Button: { child: "box-1c-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-2a", component: { Button: { child: "box-2a-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-2b", component: { Button: { child: "box-2b-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-2c", component: { Button: { child: "box-2c-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-3a", component: { Button: { child: "box-3a-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-3b", component: { Button: { child: "box-3b-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-3c", component: { Button: { child: "box-3c-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-4a", component: { Button: { child: "box-4a-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-4b", component: { Button: { child: "box-4b-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-4c", component: { Button: { child: "box-4c-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-5a", component: { Button: { child: "box-5a-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-5b", component: { Button: { child: "box-5b-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-5c", component: { Button: { child: "box-5c-text", primary: false, action: { name: "demo" } } } },
-        { id: "box-1a-text", component: { Text: { text: { literalString: "[1a]" }, usageHint: "caption" } } },
-        { id: "box-1b-text", component: { Text: { text: { literalString: "[1b]" }, usageHint: "caption" } } },
-        { id: "box-1c-text", component: { Text: { text: { literalString: "[1c]" }, usageHint: "caption" } } },
-        { id: "box-2a-text", component: { Text: { text: { literalString: "[2a]" }, usageHint: "caption" } } },
-        { id: "box-2b-text", component: { Text: { text: { literalString: "[2b]" }, usageHint: "caption" } } },
-        { id: "box-2c-text", component: { Text: { text: { literalString: "[2c]" }, usageHint: "caption" } } },
-        { id: "box-3a-text", component: { Text: { text: { literalString: "[3a]" }, usageHint: "caption" } } },
-        { id: "box-3b-text", component: { Text: { text: { literalString: "[3b]" }, usageHint: "caption" } } },
-        { id: "box-3c-text", component: { Text: { text: { literalString: "[3c]" }, usageHint: "caption" } } },
-        { id: "box-4a-text", component: { Text: { text: { literalString: "[4a]" }, usageHint: "caption" } } },
-        { id: "box-4b-text", component: { Text: { text: { literalString: "[4b]" }, usageHint: "caption" } } },
-        { id: "box-4c-text", component: { Text: { text: { literalString: "[4c]" }, usageHint: "caption" } } },
-        { id: "box-5a-text", component: { Text: { text: { literalString: "[5a]" }, usageHint: "caption" } } },
-        { id: "box-5b-text", component: { Text: { text: { literalString: "[5b]" }, usageHint: "caption" } } },
-        { id: "box-5c-text", component: { Text: { text: { literalString: "[5c]" }, usageHint: "caption" } } },
-        // Column demos
-        {
-          id: "column-demos",
-          component: {
-            Column: {
-              children: { explicitList: ["col-header", "col-demos-row"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "col-header",
-          component: {
-            Text: {
-              text: { literalString: "Column Alignment" },
-              usageHint: "h4",
-            },
-          },
-        },
-        {
-          id: "col-demos-row",
-          component: {
-            Row: {
-              children: { explicitList: ["col-start-card", "col-center-card", "col-end-card"] },
-              distribution: "spaceEvenly",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "col-start-card",
-          component: { Card: { child: "col-start-content" } },
-        },
-        {
-          id: "col-start-content",
-          component: {
-            Column: {
-              children: {
-                explicitList: ["col-start-label", "col-start-item-1", "col-start-item-2"],
-              },
-              distribution: "start",
-              alignment: "start",
-            },
-          },
-        },
-        {
-          id: "col-start-label",
-          component: {
-            Text: {
-              text: { literalString: "align: start" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "col-start-item-1",
-          component: {
-            Text: { text: { literalString: "Item 1" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "col-start-item-2",
-          component: {
-            Text: { text: { literalString: "Item 2" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "col-center-card",
-          component: { Card: { child: "col-center-content" } },
-        },
-        {
-          id: "col-center-content",
-          component: {
-            Column: {
-              children: {
-                explicitList: ["col-center-label", "col-center-item-1", "col-center-item-2"],
-              },
-              distribution: "start",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "col-center-label",
-          component: {
-            Text: {
-              text: { literalString: "align: center" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "col-center-item-1",
-          component: {
-            Text: { text: { literalString: "Item 1" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "col-center-item-2",
-          component: {
-            Text: { text: { literalString: "Item 2" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "col-end-card",
-          component: { Card: { child: "col-end-content" } },
-        },
-        {
-          id: "col-end-content",
-          component: {
-            Column: {
-              children: { explicitList: ["col-end-label", "col-end-item-1", "col-end-item-2"] },
-              distribution: "start",
-              alignment: "end",
-            },
-          },
-        },
-        {
-          id: "col-end-label",
-          component: {
-            Text: {
-              text: { literalString: "align: end" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "col-end-item-1",
-          component: {
-            Text: { text: { literalString: "Item 1" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "col-end-item-2",
-          component: {
-            Text: { text: { literalString: "Item 2" }, usageHint: "body" },
-          },
-        },
-      ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
     },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: [
+              "layout-header",
+              "row-demos",
+              "column-demos",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "layout-header",
+            component: "Text",
+            text: "Layout Examples",
+            variant: "h2",
+          },
+          {
+            id: "row-demos",
+            component: "Column",
+            children: [
+              "row-header",
+              "row-start",
+              "row-center",
+              "row-end",
+              "row-between",
+              "row-evenly",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "row-header",
+            component: "Text",
+            text: "Row Distribution",
+            variant: "h4",
+          },
+          {
+            id: "row-start",
+            component: "Card",
+            child: "row-start-content",
+          },
+          {
+            id: "row-start-content",
+            component: "Column",
+            children: [
+              "row-start-label",
+              "row-start-demo",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "row-start-label",
+            component: "Text",
+            text: "distribution: start",
+            variant: "caption",
+          },
+          {
+            id: "row-start-demo",
+            component: "Row",
+            children: [
+              "box-1a",
+              "box-1b",
+              "box-1c",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "row-center",
+            component: "Card",
+            child: "row-center-content",
+          },
+          {
+            id: "row-center-content",
+            component: "Column",
+            children: [
+              "row-center-label",
+              "row-center-demo",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "row-center-label",
+            component: "Text",
+            text: "distribution: center",
+            variant: "caption",
+          },
+          {
+            id: "row-center-demo",
+            component: "Row",
+            children: [
+              "box-2a",
+              "box-2b",
+              "box-2c",
+            ],
+            justify: "center",
+            align: "center",
+          },
+          {
+            id: "row-end",
+            component: "Card",
+            child: "row-end-content",
+          },
+          {
+            id: "row-end-content",
+            component: "Column",
+            children: [
+              "row-end-label",
+              "row-end-demo",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "row-end-label",
+            component: "Text",
+            text: "distribution: end",
+            variant: "caption",
+          },
+          {
+            id: "row-end-demo",
+            component: "Row",
+            children: [
+              "box-3a",
+              "box-3b",
+              "box-3c",
+            ],
+            justify: "end",
+            align: "center",
+          },
+          {
+            id: "row-between",
+            component: "Card",
+            child: "row-between-content",
+          },
+          {
+            id: "row-between-content",
+            component: "Column",
+            children: [
+              "row-between-label",
+              "row-between-demo",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "row-between-label",
+            component: "Text",
+            text: "distribution: spaceBetween",
+            variant: "caption",
+          },
+          {
+            id: "row-between-demo",
+            component: "Row",
+            children: [
+              "box-4a",
+              "box-4b",
+              "box-4c",
+            ],
+            justify: "spaceBetween",
+            align: "center",
+          },
+          {
+            id: "row-evenly",
+            component: "Card",
+            child: "row-evenly-content",
+          },
+          {
+            id: "row-evenly-content",
+            component: "Column",
+            children: [
+              "row-evenly-label",
+              "row-evenly-demo",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "row-evenly-label",
+            component: "Text",
+            text: "distribution: spaceEvenly",
+            variant: "caption",
+          },
+          {
+            id: "row-evenly-demo",
+            component: "Row",
+            children: [
+              "box-5a",
+              "box-5b",
+              "box-5c",
+            ],
+            justify: "spaceEvenly",
+            align: "center",
+          },
+          {
+            id: "box-1a",
+            component: "Button",
+            child: "box-1a-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-1b",
+            component: "Button",
+            child: "box-1b-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-1c",
+            component: "Button",
+            child: "box-1c-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-2a",
+            component: "Button",
+            child: "box-2a-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-2b",
+            component: "Button",
+            child: "box-2b-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-2c",
+            component: "Button",
+            child: "box-2c-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-3a",
+            component: "Button",
+            child: "box-3a-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-3b",
+            component: "Button",
+            child: "box-3b-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-3c",
+            component: "Button",
+            child: "box-3c-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-4a",
+            component: "Button",
+            child: "box-4a-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-4b",
+            component: "Button",
+            child: "box-4b-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-4c",
+            component: "Button",
+            child: "box-4c-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-5a",
+            component: "Button",
+            child: "box-5a-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-5b",
+            component: "Button",
+            child: "box-5b-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-5c",
+            component: "Button",
+            child: "box-5c-text",
+            action: {
+              event: {
+                name: "demo",
+              },
+            },
+            variant: "default",
+          },
+          {
+            id: "box-1a-text",
+            component: "Text",
+            text: "[1a]",
+            variant: "caption",
+          },
+          {
+            id: "box-1b-text",
+            component: "Text",
+            text: "[1b]",
+            variant: "caption",
+          },
+          {
+            id: "box-1c-text",
+            component: "Text",
+            text: "[1c]",
+            variant: "caption",
+          },
+          {
+            id: "box-2a-text",
+            component: "Text",
+            text: "[2a]",
+            variant: "caption",
+          },
+          {
+            id: "box-2b-text",
+            component: "Text",
+            text: "[2b]",
+            variant: "caption",
+          },
+          {
+            id: "box-2c-text",
+            component: "Text",
+            text: "[2c]",
+            variant: "caption",
+          },
+          {
+            id: "box-3a-text",
+            component: "Text",
+            text: "[3a]",
+            variant: "caption",
+          },
+          {
+            id: "box-3b-text",
+            component: "Text",
+            text: "[3b]",
+            variant: "caption",
+          },
+          {
+            id: "box-3c-text",
+            component: "Text",
+            text: "[3c]",
+            variant: "caption",
+          },
+          {
+            id: "box-4a-text",
+            component: "Text",
+            text: "[4a]",
+            variant: "caption",
+          },
+          {
+            id: "box-4b-text",
+            component: "Text",
+            text: "[4b]",
+            variant: "caption",
+          },
+          {
+            id: "box-4c-text",
+            component: "Text",
+            text: "[4c]",
+            variant: "caption",
+          },
+          {
+            id: "box-5a-text",
+            component: "Text",
+            text: "[5a]",
+            variant: "caption",
+          },
+          {
+            id: "box-5b-text",
+            component: "Text",
+            text: "[5b]",
+            variant: "caption",
+          },
+          {
+            id: "box-5c-text",
+            component: "Text",
+            text: "[5c]",
+            variant: "caption",
+          },
+          {
+            id: "column-demos",
+            component: "Column",
+            children: [
+              "col-header",
+              "col-demos-row",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "col-header",
+            component: "Text",
+            text: "Column Alignment",
+            variant: "h4",
+          },
+          {
+            id: "col-demos-row",
+            component: "Row",
+            children: [
+              "col-start-card",
+              "col-center-card",
+              "col-end-card",
+            ],
+            justify: "spaceEvenly",
+            align: "stretch",
+          },
+          {
+            id: "col-start-card",
+            component: "Card",
+            child: "col-start-content",
+          },
+          {
+            id: "col-start-content",
+            component: "Column",
+            children: [
+              "col-start-label",
+              "col-start-item-1",
+              "col-start-item-2",
+            ],
+            justify: "start",
+            align: "start",
+          },
+          {
+            id: "col-start-label",
+            component: "Text",
+            text: "align: start",
+            variant: "caption",
+          },
+          {
+            id: "col-start-item-1",
+            component: "Text",
+            text: "Item 1",
+            variant: "body",
+          },
+          {
+            id: "col-start-item-2",
+            component: "Text",
+            text: "Item 2",
+            variant: "body",
+          },
+          {
+            id: "col-center-card",
+            component: "Card",
+            child: "col-center-content",
+          },
+          {
+            id: "col-center-content",
+            component: "Column",
+            children: [
+              "col-center-label",
+              "col-center-item-1",
+              "col-center-item-2",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "col-center-label",
+            component: "Text",
+            text: "align: center",
+            variant: "caption",
+          },
+          {
+            id: "col-center-item-1",
+            component: "Text",
+            text: "Item 1",
+            variant: "body",
+          },
+          {
+            id: "col-center-item-2",
+            component: "Text",
+            text: "Item 2",
+            variant: "body",
+          },
+          {
+            id: "col-end-card",
+            component: "Card",
+            child: "col-end-content",
+          },
+          {
+            id: "col-end-content",
+            component: "Column",
+            children: [
+              "col-end-label",
+              "col-end-item-1",
+              "col-end-item-2",
+            ],
+            justify: "start",
+            align: "end",
+          },
+          {
+            id: "col-end-label",
+            component: "Text",
+            text: "align: end",
+            variant: "caption",
+          },
+          {
+            id: "col-end-item-1",
+            component: "Text",
+            text: "Item 1",
+            variant: "body",
+          },
+          {
+            id: "col-end-item-2",
+            component: "Text",
+            text: "Item 2",
+            variant: "body",
+          },
+        ],
+      },
     },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/product.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/product.ts
@@ -1,232 +1,233 @@
 // ============================================================================
-// SAMPLE: Product - E-commerce product card
+// SAMPLE: Product - Product card with actions
 // ============================================================================
 export const productSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: { Card: { child: "product-content" } },
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "main",
+        value: {
+          product: {
+            id: "PRD-12345",
+            image: "https://picsum.photos/seed/product/400/300",
+            category: "Electronics > Audio",
+            name: "Premium Wireless Headphones",
+            rating: "★★★★☆ 4.5 (128 reviews)",
+            price: "$199.99",
+            originalPrice: "$249.99 (-20%)",
+            description: "Experience crystal-clear audio with active noise cancellation, 30-hour battery life, and premium comfort for all-day listening.",
+            quantity: 1,
+          },
         },
-        {
-          id: "product-content",
-          component: {
-            Column: {
-              children: { explicitList: ["product-image", "product-details", "product-actions"] },
-              distribution: "start",
-              alignment: "stretch",
+      },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Card",
+            child: "product-content",
+          },
+          {
+            id: "product-content",
+            component: "Column",
+            children: [
+              "product-image",
+              "product-details",
+              "product-actions",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "product-image",
+            component: "Image",
+            url: {
+              path: "/product/image",
             },
+            fit: "contain",
+            variant: "largeFeature",
           },
-        },
-        {
-          id: "product-image",
-          component: {
-            Image: {
-              url: { path: "/product/image" },
-              fit: "contain",
-              usageHint: "largeFeature",
+          {
+            id: "product-details",
+            component: "Column",
+            children: [
+              "product-category",
+              "product-name",
+              "product-rating",
+              "product-price",
+              "product-description",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "product-category",
+            component: "Text",
+            text: {
+              path: "/product/category",
             },
+            variant: "caption",
           },
-        },
-        {
-          id: "product-details",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "product-category",
-                  "product-name",
-                  "product-rating",
-                  "product-price",
-                  "product-description",
-                ],
-              },
-              distribution: "start",
-              alignment: "stretch",
+          {
+            id: "product-name",
+            component: "Text",
+            text: {
+              path: "/product/name",
             },
+            variant: "h3",
           },
-        },
-        {
-          id: "product-category",
-          component: {
-            Text: { text: { path: "/product/category" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "product-name",
-          component: {
-            Text: { text: { path: "/product/name" }, usageHint: "h3" },
-          },
-        },
-        {
-          id: "product-rating",
-          component: {
-            Text: { text: { path: "/product/rating" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "product-price",
-          component: {
-            Row: {
-              children: { explicitList: ["current-price", "original-price"] },
-              distribution: "start",
-              alignment: "center",
+          {
+            id: "product-rating",
+            component: "Text",
+            text: {
+              path: "/product/rating",
             },
+            variant: "caption",
           },
-        },
-        {
-          id: "current-price",
-          component: {
-            Text: { text: { path: "/product/price" }, usageHint: "h2" },
+          {
+            id: "product-price",
+            component: "Row",
+            children: [
+              "current-price",
+              "original-price",
+            ],
+            justify: "start",
+            align: "center",
           },
-        },
-        {
-          id: "original-price",
-          component: {
-            Text: {
-              text: { path: "/product/originalPrice" },
-              usageHint: "caption",
+          {
+            id: "current-price",
+            component: "Text",
+            text: {
+              path: "/product/price",
             },
+            variant: "h2",
           },
-        },
-        {
-          id: "product-description",
-          component: {
-            Text: { text: { path: "/product/description" }, usageHint: "body" },
-          },
-        },
-        // Quantity and actions
-        {
-          id: "product-actions",
-          component: {
-            Column: {
-              children: { explicitList: ["quantity-row", "divider", "button-row"] },
-              distribution: "start",
-              alignment: "stretch",
+          {
+            id: "original-price",
+            component: "Text",
+            text: {
+              path: "/product/originalPrice",
             },
+            variant: "caption",
           },
-        },
-        {
-          id: "quantity-row",
-          component: {
-            Row: {
-              children: { explicitList: ["quantity-label", "quantity-field"] },
-              distribution: "spaceBetween",
-              alignment: "center",
+          {
+            id: "product-description",
+            component: "Text",
+            text: {
+              path: "/product/description",
             },
+            variant: "body",
           },
-        },
-        {
-          id: "quantity-label",
-          component: {
-            Text: { text: { literalString: "Quantity" }, usageHint: "body" },
+          {
+            id: "product-actions",
+            component: "Column",
+            children: [
+              "quantity-row",
+              "divider",
+              "button-row",
+            ],
+            justify: "start",
+            align: "stretch",
           },
-        },
-        {
-          id: "quantity-field",
-          component: {
-            TextField: {
-              label: { literalString: "" },
-              text: { path: "/product/quantity" },
-              textFieldType: "number",
+          {
+            id: "quantity-row",
+            component: "Row",
+            children: [
+              "quantity-label",
+              "quantity-field",
+            ],
+            justify: "spaceBetween",
+            align: "center",
+          },
+          {
+            id: "quantity-label",
+            component: "Text",
+            text: "Quantity",
+            variant: "body",
+          },
+          {
+            id: "quantity-field",
+            component: "TextField",
+            label: "",
+            value: {
+              path: "/product/quantity",
             },
+            variant: "number",
           },
-        },
-        {
-          id: "divider",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "button-row",
-          component: {
-            Row: {
-              children: { explicitList: ["wishlist-btn", "cart-btn"] },
-              distribution: "spaceEvenly",
-              alignment: "center",
-            },
+          {
+            id: "divider",
+            component: "Divider",
+            axis: "horizontal",
           },
-        },
-        {
-          id: "wishlist-btn",
-          component: {
-            Button: {
-              child: "wishlist-text",
-              action: {
+          {
+            id: "button-row",
+            component: "Row",
+            children: [
+              "wishlist-btn",
+              "cart-btn",
+            ],
+            justify: "spaceEvenly",
+            align: "center",
+          },
+          {
+            id: "wishlist-btn",
+            component: "Button",
+            child: "wishlist-text",
+            action: {
+              event: {
                 name: "add_to_wishlist",
-                context: [{ key: "productId", value: { path: "/product/id" } }],
+                context: {
+                  productId: {
+                    path: "/product/id",
+                  },
+                },
               },
-              primary: false,
             },
+            variant: "default",
           },
-        },
-        {
-          id: "wishlist-text",
-          component: {
-            Text: { text: { literalString: "♡ Wishlist" }, usageHint: "body" },
+          {
+            id: "wishlist-text",
+            component: "Text",
+            text: "♡ Wishlist",
+            variant: "body",
           },
-        },
-        {
-          id: "cart-btn",
-          component: {
-            Button: {
-              child: "cart-text",
-              action: {
+          {
+            id: "cart-btn",
+            component: "Button",
+            child: "cart-text",
+            action: {
+              event: {
                 name: "add_to_cart",
-                context: [
-                  { key: "productId", value: { path: "/product/id" } },
-                  { key: "quantity", value: { path: "/product/quantity" } },
-                ],
+                context: {
+                  productId: {
+                    path: "/product/id",
+                  },
+                  quantity: {
+                    path: "/product/quantity",
+                  },
+                },
               },
-              primary: true,
             },
+            variant: "primary",
           },
-        },
-        {
-          id: "cart-text",
-          component: {
-            Text: {
-              text: { literalString: "🛒 Add to Cart" },
-              usageHint: "body",
-            },
+          {
+            id: "cart-text",
+            component: "Text",
+            text: "🛒 Add to Cart",
+            variant: "body",
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      contents: [
-        {
-          key: "product",
-          valueMap: [
-            { key: "id", valueString: "PRD-12345" },
-            {
-              key: "image",
-              valueString: "https://picsum.photos/seed/product/400/300",
-            },
-            { key: "category", valueString: "Electronics > Audio" },
-            { key: "name", valueString: "Premium Wireless Headphones" },
-            { key: "rating", valueString: "★★★★☆ 4.5 (128 reviews)" },
-            { key: "price", valueString: "$199.99" },
-            { key: "originalPrice", valueString: "$249.99 (-20%)" },
-            {
-              key: "description",
-              valueString:
-                "Experience crystal-clear audio with active noise cancellation, 30-hour battery life, and premium comfort for all-day listening.",
-            },
-            { key: "quantity", valueNumber: 1 },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
-    },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/profile.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/profile.ts
@@ -2,247 +2,263 @@
 // SAMPLE: Profile - User profile card
 // ============================================================================
 export const profileSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: { Card: { child: "profile-content" } },
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "main",
+        value: {
+          user: {
+            avatar: "https://i.pravatar.cc/200?img=8",
+            name: "Sarah Chen",
+            role: "Senior Product Designer",
+            status: "🟢 Online",
+            email: "sarah.chen@company.com",
+            location: "San Francisco, CA",
+            joined: "January 2023",
+          },
         },
-        {
-          id: "profile-content",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "profile-header",
-                  "divider-1",
-                  "profile-details",
-                  "divider-2",
-                  "profile-actions",
-                ],
+      },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Card",
+            child: "profile-content",
+          },
+          {
+            id: "profile-content",
+            component: "Column",
+            children: [
+              "profile-header",
+              "divider-1",
+              "profile-details",
+              "divider-2",
+              "profile-actions",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "profile-header",
+            component: "Row",
+            children: [
+              "profile-avatar",
+              "profile-info",
+            ],
+            justify: "start",
+            align: "center",
+          },
+          {
+            id: "profile-avatar",
+            component: "Image",
+            url: {
+              path: "/user/avatar",
+            },
+            fit: "cover",
+            variant: "avatar",
+          },
+          {
+            id: "profile-info",
+            component: "Column",
+            children: [
+              "profile-name",
+              "profile-role",
+              "profile-status",
+            ],
+            justify: "start",
+            align: "start",
+          },
+          {
+            id: "profile-name",
+            component: "Text",
+            text: {
+              path: "/user/name",
+            },
+            variant: "h3",
+          },
+          {
+            id: "profile-role",
+            component: "Text",
+            text: {
+              path: "/user/role",
+            },
+            variant: "body",
+          },
+          {
+            id: "profile-status",
+            component: "Text",
+            text: {
+              path: "/user/status",
+            },
+            variant: "caption",
+          },
+          {
+            id: "divider-1",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "profile-details",
+            component: "Column",
+            children: [
+              "detail-email",
+              "detail-location",
+              "detail-joined",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "detail-email",
+            component: "Row",
+            children: [
+              "email-label",
+              "email-value",
+            ],
+            justify: "spaceBetween",
+            align: "center",
+          },
+          {
+            id: "email-label",
+            component: "Text",
+            text: "Email",
+            variant: "caption",
+          },
+          {
+            id: "email-value",
+            component: "Text",
+            text: {
+              path: "/user/email",
+            },
+            variant: "body",
+          },
+          {
+            id: "detail-location",
+            component: "Row",
+            children: [
+              "location-label",
+              "location-value",
+            ],
+            justify: "spaceBetween",
+            align: "center",
+          },
+          {
+            id: "location-label",
+            component: "Text",
+            text: "Location",
+            variant: "caption",
+          },
+          {
+            id: "location-value",
+            component: "Text",
+            text: {
+              path: "/user/location",
+            },
+            variant: "body",
+          },
+          {
+            id: "detail-joined",
+            component: "Row",
+            children: [
+              "joined-label",
+              "joined-value",
+            ],
+            justify: "spaceBetween",
+            align: "center",
+          },
+          {
+            id: "joined-label",
+            component: "Text",
+            text: "Joined",
+            variant: "caption",
+          },
+          {
+            id: "joined-value",
+            component: "Text",
+            text: {
+              path: "/user/joined",
+            },
+            variant: "body",
+          },
+          {
+            id: "divider-2",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "profile-actions",
+            component: "Row",
+            children: [
+              "edit-btn",
+              "message-btn",
+              "more-btn",
+            ],
+            justify: "spaceEvenly",
+            align: "center",
+          },
+          {
+            id: "edit-btn",
+            component: "Button",
+            child: "edit-text",
+            action: {
+              event: {
+                name: "edit_profile",
               },
-              distribution: "start",
-              alignment: "stretch",
             },
+            variant: "primary",
           },
-        },
-        {
-          id: "profile-header",
-          component: {
-            Row: {
-              children: { explicitList: ["profile-avatar", "profile-info"] },
-              distribution: "start",
-              alignment: "center",
+          {
+            id: "edit-text",
+            component: "Text",
+            text: "Edit Profile",
+            variant: "body",
+          },
+          {
+            id: "message-btn",
+            component: "Button",
+            child: "message-text",
+            action: {
+              event: {
+                name: "send_message",
+              },
             },
+            variant: "default",
           },
-        },
-        {
-          id: "profile-avatar",
-          component: {
-            Image: {
-              url: { path: "/user/avatar" },
-              fit: "cover",
-              usageHint: "avatar",
+          {
+            id: "message-text",
+            component: "Text",
+            text: "Message",
+            variant: "body",
+          },
+          {
+            id: "more-btn",
+            component: "Button",
+            child: "more-text",
+            action: {
+              event: {
+                name: "more_options",
+              },
             },
+            variant: "default",
           },
-        },
-        {
-          id: "profile-info",
-          component: {
-            Column: {
-              children: { explicitList: ["profile-name", "profile-role", "profile-status"] },
-              distribution: "start",
-              alignment: "start",
-            },
+          {
+            id: "more-text",
+            component: "Text",
+            text: "...",
+            variant: "body",
           },
-        },
-        {
-          id: "profile-name",
-          component: {
-            Text: { text: { path: "/user/name" }, usageHint: "h3" },
-          },
-        },
-        {
-          id: "profile-role",
-          component: {
-            Text: { text: { path: "/user/role" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "profile-status",
-          component: {
-            Text: {
-              text: { path: "/user/status" },
-              usageHint: "caption",
-            },
-          },
-        },
-        {
-          id: "divider-1",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "profile-details",
-          component: {
-            Column: {
-              children: { explicitList: ["detail-email", "detail-location", "detail-joined"] },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "detail-email",
-          component: {
-            Row: {
-              children: { explicitList: ["email-label", "email-value"] },
-              distribution: "spaceBetween",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "email-label",
-          component: {
-            Text: { text: { literalString: "Email" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "email-value",
-          component: {
-            Text: { text: { path: "/user/email" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "detail-location",
-          component: {
-            Row: {
-              children: { explicitList: ["location-label", "location-value"] },
-              distribution: "spaceBetween",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "location-label",
-          component: {
-            Text: { text: { literalString: "Location" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "location-value",
-          component: {
-            Text: { text: { path: "/user/location" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "detail-joined",
-          component: {
-            Row: {
-              children: { explicitList: ["joined-label", "joined-value"] },
-              distribution: "spaceBetween",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "joined-label",
-          component: {
-            Text: { text: { literalString: "Joined" }, usageHint: "caption" },
-          },
-        },
-        {
-          id: "joined-value",
-          component: {
-            Text: { text: { path: "/user/joined" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "divider-2",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        {
-          id: "profile-actions",
-          component: {
-            Row: {
-              children: { explicitList: ["edit-btn", "message-btn", "more-btn"] },
-              distribution: "spaceEvenly",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "edit-btn",
-          component: {
-            Button: {
-              child: "edit-text",
-              action: { name: "edit_profile" },
-              primary: true,
-            },
-          },
-        },
-        {
-          id: "edit-text",
-          component: {
-            Text: { text: { literalString: "Edit Profile" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "message-btn",
-          component: {
-            Button: {
-              child: "message-text",
-              action: { name: "send_message" },
-              primary: false,
-            },
-          },
-        },
-        {
-          id: "message-text",
-          component: {
-            Text: { text: { literalString: "Message" }, usageHint: "body" },
-          },
-        },
-        {
-          id: "more-btn",
-          component: {
-            Button: {
-              child: "more-text",
-              action: { name: "more_options" },
-              primary: false,
-            },
-          },
-        },
-        {
-          id: "more-text",
-          component: {
-            Text: { text: { literalString: "..." }, usageHint: "body" },
-          },
-        },
-      ],
+        ],
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      path: "/user",
-      contents: [
-        { key: "avatar", valueString: "https://i.pravatar.cc/200?img=8" },
-        { key: "name", valueString: "Sarah Chen" },
-        { key: "role", valueString: "Senior Product Designer" },
-        { key: "status", valueString: "🟢 Online" },
-        { key: "email", valueString: "sarah.chen@company.com" },
-        { key: "location", valueString: "San Francisco, CA" },
-        { key: "joined", valueString: "January 2023" },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
-    },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/setting.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/setting.ts
@@ -1,225 +1,220 @@
 // ============================================================================
-// SAMPLE: Settings - Configuration panel with checkboxes
+// SAMPLE: Settings - Configuration panel
 // ============================================================================
 export const settingsSample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "settings-header",
-                  "divider-top",
-                  "notifications-section",
-                  "divider-mid",
-                  "privacy-section",
-                  "divider-bottom",
-                  "save-row",
-                ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "main",
+        value: {
+          settings: {
+            emailNotif: true,
+            pushNotif: true,
+            smsNotif: false,
+            publicProfile: true,
+            showEmail: false,
+            showActivity: true,
+          },
+        },
+      },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: [
+              "settings-header",
+              "divider-top",
+              "notifications-section",
+              "divider-mid",
+              "privacy-section",
+              "divider-bottom",
+              "save-row",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "settings-header",
+            component: "Text",
+            text: "⚙️ Settings",
+            variant: "h2",
+          },
+          {
+            id: "divider-top",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "notifications-section",
+            component: "Column",
+            children: [
+              "notifications-header",
+              "email-notif",
+              "push-notif",
+              "sms-notif",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "notifications-header",
+            component: "Text",
+            text: "Notifications",
+            variant: "h4",
+          },
+          {
+            id: "email-notif",
+            component: "CheckBox",
+            label: "Email notifications",
+            value: {
+              path: "/settings/emailNotif",
+            },
+          },
+          {
+            id: "push-notif",
+            component: "CheckBox",
+            label: "Push notifications",
+            value: {
+              path: "/settings/pushNotif",
+            },
+          },
+          {
+            id: "sms-notif",
+            component: "CheckBox",
+            label: "SMS notifications",
+            value: {
+              path: "/settings/smsNotif",
+            },
+          },
+          {
+            id: "divider-mid",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "privacy-section",
+            component: "Column",
+            children: [
+              "privacy-header",
+              "public-profile",
+              "show-email",
+              "show-activity",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "privacy-header",
+            component: "Text",
+            text: "Privacy",
+            variant: "h4",
+          },
+          {
+            id: "public-profile",
+            component: "CheckBox",
+            label: "Make profile public",
+            value: {
+              path: "/settings/publicProfile",
+            },
+          },
+          {
+            id: "show-email",
+            component: "CheckBox",
+            label: "Show email on profile",
+            value: {
+              path: "/settings/showEmail",
+            },
+          },
+          {
+            id: "show-activity",
+            component: "CheckBox",
+            label: "Show activity status",
+            value: {
+              path: "/settings/showActivity",
+            },
+          },
+          {
+            id: "divider-bottom",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "save-row",
+            component: "Row",
+            children: [
+              "reset-btn",
+              "save-btn",
+            ],
+            justify: "end",
+            align: "center",
+          },
+          {
+            id: "reset-btn",
+            component: "Button",
+            child: "reset-text",
+            action: {
+              event: {
+                name: "reset_settings",
               },
-              distribution: "start",
-              alignment: "stretch",
             },
+            variant: "default",
           },
-        },
-        {
-          id: "settings-header",
-          component: {
-            Text: { text: { literalString: "⚙️ Settings" }, usageHint: "h2" },
+          {
+            id: "reset-text",
+            component: "Text",
+            text: "Reset to Default",
+            variant: "body",
           },
-        },
-        {
-          id: "divider-top",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        // Notifications section
-        {
-          id: "notifications-section",
-          component: {
-            Column: {
-              children: {
-                explicitList: ["notifications-header", "email-notif", "push-notif", "sms-notif"],
-              },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "notifications-header",
-          component: {
-            Text: { text: { literalString: "Notifications" }, usageHint: "h4" },
-          },
-        },
-        {
-          id: "email-notif",
-          component: {
-            CheckBox: {
-              label: { literalString: "Email notifications" },
-              value: { path: "/settings/emailNotif" },
-            },
-          },
-        },
-        {
-          id: "push-notif",
-          component: {
-            CheckBox: {
-              label: { literalString: "Push notifications" },
-              value: { path: "/settings/pushNotif" },
-            },
-          },
-        },
-        {
-          id: "sms-notif",
-          component: {
-            CheckBox: {
-              label: { literalString: "SMS notifications" },
-              value: { path: "/settings/smsNotif" },
-            },
-          },
-        },
-        {
-          id: "divider-mid",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        // Privacy section
-        {
-          id: "privacy-section",
-          component: {
-            Column: {
-              children: {
-                explicitList: ["privacy-header", "public-profile", "show-email", "show-activity"],
-              },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "privacy-header",
-          component: {
-            Text: { text: { literalString: "Privacy" }, usageHint: "h4" },
-          },
-        },
-        {
-          id: "public-profile",
-          component: {
-            CheckBox: {
-              label: { literalString: "Make profile public" },
-              value: { path: "/settings/publicProfile" },
-            },
-          },
-        },
-        {
-          id: "show-email",
-          component: {
-            CheckBox: {
-              label: { literalString: "Show email on profile" },
-              value: { path: "/settings/showEmail" },
-            },
-          },
-        },
-        {
-          id: "show-activity",
-          component: {
-            CheckBox: {
-              label: { literalString: "Show activity status" },
-              value: { path: "/settings/showActivity" },
-            },
-          },
-        },
-        {
-          id: "divider-bottom",
-          component: { Divider: { axis: "horizontal" } },
-        },
-        // Save row
-        {
-          id: "save-row",
-          component: {
-            Row: {
-              children: { explicitList: ["reset-btn", "save-btn"] },
-              distribution: "end",
-              alignment: "center",
-            },
-          },
-        },
-        {
-          id: "reset-btn",
-          component: {
-            Button: {
-              child: "reset-text",
-              action: { name: "reset_settings" },
-              primary: false,
-            },
-          },
-        },
-        {
-          id: "reset-text",
-          component: {
-            Text: {
-              text: { literalString: "Reset to Default" },
-              usageHint: "body",
-            },
-          },
-        },
-        {
-          id: "save-btn",
-          component: {
-            Button: {
-              child: "save-text",
-              action: {
+          {
+            id: "save-btn",
+            component: "Button",
+            child: "save-text",
+            action: {
+              event: {
                 name: "save_settings",
-                context: [
-                  { key: "emailNotif", value: { path: "/settings/emailNotif" } },
-                  { key: "pushNotif", value: { path: "/settings/pushNotif" } },
-                  { key: "smsNotif", value: { path: "/settings/smsNotif" } },
-                  { key: "publicProfile", value: { path: "/settings/publicProfile" } },
-                  { key: "showEmail", value: { path: "/settings/showEmail" } },
-                  { key: "showActivity", value: { path: "/settings/showActivity" } },
-                ],
+                context: {
+                  emailNotif: {
+                    path: "/settings/emailNotif",
+                  },
+                  pushNotif: {
+                    path: "/settings/pushNotif",
+                  },
+                  smsNotif: {
+                    path: "/settings/smsNotif",
+                  },
+                  publicProfile: {
+                    path: "/settings/publicProfile",
+                  },
+                  showEmail: {
+                    path: "/settings/showEmail",
+                  },
+                  showActivity: {
+                    path: "/settings/showActivity",
+                  },
+                },
               },
-              primary: true,
             },
+            variant: "primary",
           },
-        },
-        {
-          id: "save-text",
-          component: {
-            Text: {
-              text: { literalString: "Save Changes" },
-              usageHint: "body",
-            },
+          {
+            id: "save-text",
+            component: "Text",
+            text: "Save Changes",
+            variant: "body",
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-  {
-    dataModelUpdate: {
-      surfaceId: "main",
-      contents: [
-        {
-          key: "settings",
-          valueMap: [
-            { key: "emailNotif", valueBoolean: true },
-            { key: "pushNotif", valueBoolean: true },
-            { key: "smsNotif", valueBoolean: false },
-            { key: "publicProfile", valueBoolean: true },
-            { key: "showEmail", valueBoolean: false },
-            { key: "showActivity", valueBoolean: true },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
-    },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/typography.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/sampleAgentData/typography.ts
@@ -2,113 +2,82 @@
 // SAMPLE: Typography - All text usage hints
 // ============================================================================
 export const typographySample = [
-  {
-    surfaceUpdate: {
-      surfaceId: "main",
-      components: [
-        {
-          id: "root",
-          component: {
-            Column: {
-              children: {
-                explicitList: [
-                  "h1-text",
-                  "h2-text",
-                  "h3-text",
-                  "h4-text",
-                  "h5-text",
-                  "divider-1",
-                  "body-text",
-                  "caption-text",
-                ],
-              },
-              distribution: "start",
-              alignment: "stretch",
-            },
-          },
-        },
-        {
-          id: "h1-text",
-          component: {
-            Text: {
-              text: { literalString: "Heading 1 - Main Title" },
-              usageHint: "h1",
-            },
-          },
-        },
-        {
-          id: "h2-text",
-          component: {
-            Text: {
-              text: { literalString: "Heading 2 - Section Title" },
-              usageHint: "h2",
-            },
-          },
-        },
-        {
-          id: "h3-text",
-          component: {
-            Text: {
-              text: { literalString: "Heading 3 - Subsection" },
-              usageHint: "h3",
-            },
-          },
-        },
-        {
-          id: "h4-text",
-          component: {
-            Text: {
-              text: { literalString: "Heading 4 - Minor Heading" },
-              usageHint: "h4",
-            },
-          },
-        },
-        {
-          id: "h5-text",
-          component: {
-            Text: {
-              text: { literalString: "Heading 5 - Small Heading" },
-              usageHint: "h5",
-            },
-          },
-        },
-        {
-          id: "divider-1",
-          component: {
-            Divider: { axis: "horizontal" },
-          },
-        },
-        {
-          id: "body-text",
-          component: {
-            Text: {
-              text: {
-                literalString:
-                  "Body text is used for main content paragraphs. It provides comfortable reading for longer passages of text. This is the default style for most content.",
-              },
-              usageHint: "body",
-            },
-          },
-        },
-        {
-          id: "caption-text",
-          component: {
-            Text: {
-              text: {
-                literalString:
-                  "Caption text - Used for labels, hints, and supplementary information",
-              },
-              usageHint: "caption",
-            },
-          },
-        },
-      ],
+    {
+      version: "v0.9",
+      createSurface: {
+        surfaceId: "main",
+        catalogId: "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      },
     },
-  },
-  {
-    beginRendering: {
-      surfaceId: "main",
-      root: "root",
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "main",
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: [
+              "h1-text",
+              "h2-text",
+              "h3-text",
+              "h4-text",
+              "h5-text",
+              "divider-1",
+              "body-text",
+              "caption-text",
+            ],
+            justify: "start",
+            align: "stretch",
+          },
+          {
+            id: "h1-text",
+            component: "Text",
+            text: "Heading 1 - Main Title",
+            variant: "h1",
+          },
+          {
+            id: "h2-text",
+            component: "Text",
+            text: "Heading 2 - Section Title",
+            variant: "h2",
+          },
+          {
+            id: "h3-text",
+            component: "Text",
+            text: "Heading 3 - Subsection",
+            variant: "h3",
+          },
+          {
+            id: "h4-text",
+            component: "Text",
+            text: "Heading 4 - Minor Heading",
+            variant: "h4",
+          },
+          {
+            id: "h5-text",
+            component: "Text",
+            text: "Heading 5 - Small Heading",
+            variant: "h5",
+          },
+          {
+            id: "divider-1",
+            component: "Divider",
+            axis: "horizontal",
+          },
+          {
+            id: "body-text",
+            component: "Text",
+            text: "Body text is used for main content paragraphs. It provides comfortable reading for longer passages of text. This is the default style for most content.",
+            variant: "body",
+          },
+          {
+            id: "caption-text",
+            component: "Text",
+            text: "Caption text - Used for labels, hints, and supplementary information",
+            variant: "caption",
+          },
+        ],
+      },
     },
-  },
-];
+  ];

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/types/chat.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/types/chat.ts
@@ -1,7 +1,9 @@
+import type { A2UIMessage } from "glchat-a2ui-react-renderer";
+
 export interface A2APart {
   kind: "text" | "data";
   text?: string;
-  data?: object;
+  data?: A2UIMessage;
   metadata?: { mimeType: string };
 }
 

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/utils/a2uiMockMessage.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/utils/a2uiMockMessage.ts
@@ -1,3 +1,4 @@
+import { A2UIMessage } from "glchat-a2ui-react-renderer";
 import { dashboardSample } from "@/sampleAgentData/dashboard";
 import { deleteSurfaceSample } from "@/sampleAgentData/deleteSurface";
 import { formSample } from "@/sampleAgentData/form";
@@ -14,13 +15,14 @@ import { SampleType } from "@/types/chat";
 
 const deleteSurfaceAction = [
   {
+    version: "v0.9",
     deleteSurface: {
       surfaceId: "temporary",
     },
   },
 ];
 
-const samples: Record<SampleType, object[]> = {
+const samples = {
   typography: typographySample,
   form: formSample,
   gallery: gallerySample,
@@ -33,7 +35,7 @@ const samples: Record<SampleType, object[]> = {
   "delete-surface": deleteSurfaceSample,
   components: componentsSample,
   hello: helloSample,
-};
+} as Record<SampleType, A2UIMessage[]>;
 
 export function detectSampleType(input: string): SampleType {
   const lower = input.toLowerCase();
@@ -47,16 +49,17 @@ export function detectSampleType(input: string): SampleType {
   if (lower.includes("product") || lower.includes("card")) return "product";
   if (lower.includes("layout") || lower.includes("grid")) return "layout";
   if (lower.includes("delete") || lower.includes("remove")) return "delete-surface";
-  if (lower.includes("components") || lower.includes("component")) return "components";
+  if (lower.includes("components") || lower.includes("component") || lower.includes("catalog"))
+    return "components";
   return "hello";
 }
 
-export function getMockMessage(type: SampleType): object[] {
+export function getMockMessage(type: SampleType): A2UIMessage[] {
   return samples[type] ?? helloSample;
 }
 
-export function getDeleteSurfaceAction(): object[] {
-  return deleteSurfaceAction;
+export function getDeleteSurfaceAction(): A2UIMessage[] {
+  return deleteSurfaceAction as A2UIMessage[];
 }
 
 export type { SampleType };

--- a/gen-ai/examples/a2ui/a2ui-nextjs/src/utils/a2uiMockStream.ts
+++ b/gen-ai/examples/a2ui/a2ui-nextjs/src/utils/a2uiMockStream.ts
@@ -1,3 +1,4 @@
+import { A2UIMessage } from "glchat-a2ui-react-renderer";
 import { A2AMessage, A2APart, A2AResponse, ChatMessage } from "@/types/chat";
 import { detectSampleType, getDeleteSurfaceAction, getMockMessage } from "./a2uiMockMessage";
 
@@ -10,7 +11,7 @@ function createTextPart(text: string): A2APart {
   return { kind: "text", text };
 }
 
-function createA2UIDataPart(data: object): A2APart {
+function createA2UIDataPart(data: A2UIMessage): A2APart {
   return {
     data,
     kind: "data",

--- a/gen-ai/examples/a2ui/json/a2ui-sample-messages.json
+++ b/gen-ai/examples/a2ui/json/a2ui-sample-messages.json
@@ -1,0 +1,193 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "main",
+      "catalogId": "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+      "theme": {
+        "primaryColor": "#2563eb"
+      }
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "main",
+      "value": {
+        "form": {
+          "name": "Ada",
+          "agree": true,
+          "color": ["blue"],
+          "volume": 60,
+          "meeting": "2026-07-01T09:30",
+          "tags": ["alpha", "beta"],
+          "deadline": "2026-12-31T23:59:59Z"
+        }
+      }
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": [
+            "title",
+            "hero",
+            "star",
+            "clip",
+            "audio",
+            "infoRow",
+            "linkList",
+            "profileCard",
+            "tabsExample",
+            "sep",
+            "detailsModal",
+            "submitBtn",
+            "deleteBtn",
+            "docsLink",
+            "nameField",
+            "agreeBox",
+            "colorPicker",
+            "volume",
+            "meeting",
+            "tags",
+            "countdown"
+          ]
+        },
+        { "id": "title", "component": "Text", "text": "A2UI v0.9 GLChat sample", "variant": "h3" },
+        {
+          "id": "hero",
+          "component": "Image",
+          "url": "https://placehold.co/600x200",
+          "variant": "largeFeature",
+          "description": "Hero image"
+        },
+        { "id": "star", "component": "Icon", "name": "star" },
+        { "id": "clip", "component": "Video", "url": "https://www.w3schools.com/html/mov_bbb.mp4" },
+        {
+          "id": "audio",
+          "component": "AudioPlayer",
+          "url": "https://www.w3schools.com/html/horse.mp3",
+          "description": "Sample audio"
+        },
+        {
+          "id": "infoRow",
+          "component": "Row",
+          "children": ["infoLeft", "infoRight"],
+          "justify": "spaceBetween",
+          "align": "center"
+        },
+        { "id": "infoLeft", "component": "Text", "text": "Left" },
+        { "id": "infoRight", "component": "Text", "text": "Right" },
+        {
+          "id": "linkList",
+          "component": "List",
+          "children": ["item1", "item2"],
+          "direction": "vertical"
+        },
+        { "id": "item1", "component": "Text", "text": "Item one" },
+        { "id": "item2", "component": "Text", "text": "Item two" },
+        { "id": "profileCard", "component": "Card", "child": "cardText" },
+        { "id": "cardText", "component": "Text", "text": "Inside a card" },
+        {
+          "id": "tabsExample",
+          "component": "Tabs",
+          "tabs": [
+            { "title": "Tab 1", "child": "tab1Text" },
+            { "title": "Tab 2", "child": "tab2Text" }
+          ]
+        },
+        { "id": "tab1Text", "component": "Text", "text": "First tab content" },
+        { "id": "tab2Text", "component": "Text", "text": "Second tab content" },
+        { "id": "sep", "component": "Divider", "axis": "horizontal" },
+        { "id": "detailsModal", "component": "Modal", "trigger": "modalTrigger", "content": "modalContent" },
+        { "id": "modalTrigger", "component": "Text", "text": "Open details" },
+        { "id": "modalContent", "component": "Text", "text": "Modal body content" },
+        {
+          "id": "submitBtn",
+          "component": "Button",
+          "child": "submitLabel",
+          "variant": "primary",
+          "action": { "event": { "name": "submit", "context": { "form": "main" } } }
+        },
+        { "id": "submitLabel", "component": "Text", "text": "Submit" },
+        {
+          "id": "deleteBtn",
+          "component": "Button",
+          "child": "deleteLabel",
+          "variant": "destructive",
+          "action": { "event": { "name": "delete" } }
+        },
+        { "id": "deleteLabel", "component": "Text", "text": "Delete" },
+        {
+          "id": "docsLink",
+          "component": "Button",
+          "child": "docsLabel",
+          "variant": "borderless",
+          "action": {
+            "functionCall": {
+              "call": "openUrl",
+              "args": { "url": "https://a2ui.org" },
+              "returnType": "void"
+            }
+          }
+        },
+        { "id": "docsLabel", "component": "Text", "text": "Open docs" },
+        {
+          "id": "nameField",
+          "component": "TextField",
+          "label": "Name",
+          "value": { "path": "/form/name" },
+          "variant": "shortText"
+        },
+        { "id": "agreeBox", "component": "CheckBox", "label": "I agree", "value": { "path": "/form/agree" } },
+        {
+          "id": "colorPicker",
+          "component": "ChoicePicker",
+          "label": "Favorite color",
+          "variant": "mutuallyExclusive",
+          "displayStyle": "chips",
+          "options": [
+            { "label": "Red", "value": "red" },
+            { "label": "Green", "value": "green" },
+            { "label": "Blue", "value": "blue" }
+          ],
+          "value": { "path": "/form/color" }
+        },
+        {
+          "id": "volume",
+          "component": "Slider",
+          "label": "Volume",
+          "min": 0,
+          "max": 100,
+          "value": { "path": "/form/volume" }
+        },
+        {
+          "id": "meeting",
+          "component": "DateTimeInput",
+          "label": "Meeting",
+          "value": { "path": "/form/meeting" },
+          "enableDate": true,
+          "enableTime": true
+        },
+        {
+          "id": "tags",
+          "component": "TagInput",
+          "label": "Tags",
+          "value": { "path": "/form/tags" },
+          "placeholder": "Add a tag"
+        },
+        {
+          "id": "countdown",
+          "component": "Timeout",
+          "targetTimeUtc": { "path": "/form/deadline" },
+          "variant": "body"
+        }
+      ]
+    }
+  }
+]

--- a/gen-ai/examples/a2ui/json/glchat_catalog_definition.json
+++ b/gen-ai/examples/a2ui/json/glchat_catalog_definition.json
@@ -1,756 +1,1470 @@
 {
-  "catalogId": "https://github.com/gdplabs/gen-ai-sdk-cookbook/tree/main/gen-ai/examples/a2ui/json/glchat_catalog_definition.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
+  "title": "GLChat A2UI Catalog",
+  "description": "A2UI v0.9 basic catalog extended with GLChat-specific component overrides and extensions.",
+  "catalogId": "https://github.com/GDP-ADMIN/glchat-sdk/blob/main/js/glchat-a2ui-react-renderer/json/glchat_standard_catalog_definition.json",
   "components": {
     "Text": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "text": {
-          "type": "object",
-          "description": "The text content to display. This can be a literal string or a reference to a value in the data model ('path', e.g., '/doc/title'). While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation.",
-          "additionalProperties": false,
-          "properties": {
-            "literalString": {
-              "type": "string"
-            },
-            "path": {
-              "type": "string"
-            }
-          }
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
         },
-        "usageHint": {
-          "type": "string",
-          "description": "A hint for the base text style. One of:\n- `h1`: Largest heading.\n- `h2`: Second largest heading.\n- `h3`: Third largest heading.\n- `h4`: Fourth largest heading.\n- `h5`: Fifth largest heading.\n- `caption`: Small text for captions.\n- `body`: Standard body text.",
-          "enum": ["h1", "h2", "h3", "h4", "h5", "caption", "body"]
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Text"
+            },
+            "text": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the base text style.",
+              "enum": ["h1", "h2", "h3", "h4", "h5", "caption", "body"],
+              "default": "body"
+            }
+          },
+          "required": ["component", "text"]
         }
-      },
-      "required": ["text"]
+      ],
+      "unevaluatedProperties": false
     },
     "Image": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "url": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "The URL of the image to display. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/thumbnail/url').",
-          "additionalProperties": false,
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "Image"
             },
-            "path": {
-              "type": "string"
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the image to display."
+            },
+            "description": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "Accessibility text for the image."
+            },
+            "fit": {
+              "type": "string",
+              "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
+              "enum": ["contain", "cover", "fill", "none", "scaleDown"],
+              "default": "fill"
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for the image size and style.",
+              "enum": ["icon", "avatar", "smallFeature", "mediumFeature", "largeFeature", "header"],
+              "default": "mediumFeature"
             }
-          }
-        },
-        "fit": {
-          "type": "string",
-          "description": "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
-          "enum": ["contain", "cover", "fill", "none", "scale-down"]
-        },
-        "usageHint": {
-          "type": "string",
-          "description": "A hint for the image size and style. One of:\n- `icon`: Small square icon.\n- `avatar`: Circular avatar image.\n- `smallFeature`: Small feature image.\n- `mediumFeature`: Medium feature image.\n- `largeFeature`: Large feature image.\n- `header`: Full-width, full bleed, header image.",
-          "enum": ["icon", "avatar", "smallFeature", "mediumFeature", "largeFeature", "header"]
+          },
+          "required": ["component", "url"]
         }
-      },
-      "required": ["url"]
+      ],
+      "unevaluatedProperties": false
     },
     "Icon": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "The name of the icon to display. This can be a literal string or a reference to a value in the data model ('path', e.g. '/form/submit').",
-          "additionalProperties": false,
           "properties": {
-            "literalString": {
-              "type": "string",
-              "enum": [
-                "accountCircle",
-                "add",
-                "arrowBack",
-                "arrowForward",
-                "attachFile",
-                "calendarToday",
-                "call",
-                "camera",
-                "check",
-                "close",
-                "delete",
-                "download",
-                "edit",
-                "event",
-                "error",
-                "favorite",
-                "favoriteOff",
-                "folder",
-                "help",
-                "home",
-                "info",
-                "locationOn",
-                "lock",
-                "lockOpen",
-                "mail",
-                "menu",
-                "moreVert",
-                "moreHoriz",
-                "notificationsOff",
-                "notifications",
-                "payment",
-                "person",
-                "phone",
-                "photo",
-                "print",
-                "refresh",
-                "search",
-                "send",
-                "settings",
-                "share",
-                "shoppingCart",
-                "star",
-                "starHalf",
-                "starOff",
-                "upload",
-                "visibility",
-                "visibilityOff",
-                "warning"
-              ]
+            "component": {
+              "const": "Icon"
             },
-            "path": {
-              "type": "string"
+            "name": {
+              "description": "The name of the icon to display.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "accountCircle",
+                    "add",
+                    "arrowBack",
+                    "arrowForward",
+                    "attachFile",
+                    "calendarToday",
+                    "call",
+                    "camera",
+                    "check",
+                    "close",
+                    "delete",
+                    "download",
+                    "edit",
+                    "event",
+                    "error",
+                    "fastForward",
+                    "favorite",
+                    "favoriteOff",
+                    "folder",
+                    "help",
+                    "home",
+                    "info",
+                    "locationOn",
+                    "lock",
+                    "lockOpen",
+                    "mail",
+                    "menu",
+                    "moreVert",
+                    "moreHoriz",
+                    "notificationsOff",
+                    "notifications",
+                    "pause",
+                    "payment",
+                    "person",
+                    "phone",
+                    "photo",
+                    "play",
+                    "print",
+                    "refresh",
+                    "rewind",
+                    "search",
+                    "send",
+                    "settings",
+                    "share",
+                    "shoppingCart",
+                    "skipNext",
+                    "skipPrevious",
+                    "star",
+                    "starHalf",
+                    "starOff",
+                    "stop",
+                    "upload",
+                    "visibility",
+                    "visibilityOff",
+                    "volumeDown",
+                    "volumeMute",
+                    "volumeOff",
+                    "volumeUp",
+                    "warning"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "svgPath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["svgPath"],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "common_types.json#/$defs/DataBinding"
+                }
+              ]
             }
-          }
+          },
+          "required": ["component", "name"]
         }
-      },
-      "required": ["name"]
+      ],
+      "unevaluatedProperties": false
     },
     "Video": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "url": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "The URL of the video to display. This can be a literal string or a reference to a value in the data model ('path', e.g. '/video/url').",
-          "additionalProperties": false,
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "Video"
             },
-            "path": {
-              "type": "string"
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the video to display."
             }
-          }
+          },
+          "required": ["component", "url"]
         }
-      },
-      "required": ["url"]
+      ],
+      "unevaluatedProperties": false
     },
     "AudioPlayer": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "url": {
-          "type": "object",
-          "description": "The URL of the audio to be played. This can be a literal string ('literal') or a reference to a value in the data model ('path', e.g. '/song/url').",
-          "additionalProperties": false,
-          "properties": {
-            "literalString": {
-              "type": "string"
-            },
-            "path": {
-              "type": "string"
-            }
-          }
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
         },
-        "description": {
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "A description of the audio, such as a title or summary. This can be a literal string or a reference to a value in the data model ('path', e.g. '/song/title').",
-          "additionalProperties": false,
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "AudioPlayer"
             },
-            "path": {
-              "type": "string"
+            "url": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The URL of the audio to be played."
+            },
+            "description": {
+              "description": "A description of the audio, such as a title or summary.",
+              "$ref": "common_types.json#/$defs/DynamicString"
             }
-          }
+          },
+          "required": ["component", "url"]
         }
-      },
-      "required": ["url"]
+      ],
+      "unevaluatedProperties": false
     },
     "Row": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "children": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
-          "additionalProperties": false,
+          "description": "A layout component that arranges its children horizontally. To create a grid layout, nest Columns within this Row.",
           "properties": {
-            "explicitList": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "component": {
+              "const": "Row"
             },
-            "template": {
-              "type": "object",
-              "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
-              "additionalProperties": false,
-              "properties": {
-                "componentId": {
-                  "type": "string"
-                },
-                "dataBinding": {
-                  "type": "string"
-                }
-              },
-              "required": ["componentId", "dataBinding"]
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "justify": {
+              "type": "string",
+              "description": "Defines the arrangement of children along the main axis (horizontally). Use 'spaceBetween' to push items to the edges, or 'start'/'end'/'center' to pack them together.",
+              "enum": [
+                "center",
+                "end",
+                "spaceAround",
+                "spaceBetween",
+                "spaceEvenly",
+                "start",
+                "stretch"
+              ],
+              "default": "start"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis (vertically). This is similar to the CSS 'align-items' property, but uses camelCase values (e.g., 'start').",
+              "enum": ["start", "center", "end", "stretch"],
+              "default": "stretch"
             }
-          }
-        },
-        "distribution": {
-          "type": "string",
-          "description": "Defines the arrangement of children along the main axis (horizontally). This corresponds to the CSS 'justify-content' property.",
-          "enum": ["center", "end", "spaceAround", "spaceBetween", "spaceEvenly", "start"]
-        },
-        "alignment": {
-          "type": "string",
-          "description": "Defines the alignment of children along the cross axis (vertically). This corresponds to the CSS 'align-items' property.",
-          "enum": ["start", "center", "end", "stretch"]
+          },
+          "required": ["component", "children"]
         }
-      },
-      "required": ["children"]
+      ],
+      "unevaluatedProperties": false
     },
     "Column": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "children": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
-          "additionalProperties": false,
+          "description": "A layout component that arranges its children vertically. To create a grid layout, nest Rows within this Column.",
           "properties": {
-            "explicitList": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "component": {
+              "const": "Column"
             },
-            "template": {
-              "type": "object",
-              "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
-              "additionalProperties": false,
-              "properties": {
-                "componentId": {
-                  "type": "string"
-                },
-                "dataBinding": {
-                  "type": "string"
-                }
-              },
-              "required": ["componentId", "dataBinding"]
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list. Children cannot be defined inline, they must be referred to by ID.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "justify": {
+              "type": "string",
+              "description": "Defines the arrangement of children along the main axis (vertically). Use 'spaceBetween' to push items to the edges (e.g. header at top, footer at bottom), or 'start'/'end'/'center' to pack them together.",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "spaceBetween",
+                "spaceAround",
+                "spaceEvenly",
+                "stretch"
+              ],
+              "default": "start"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis (horizontally). This is similar to the CSS 'align-items' property.",
+              "enum": ["center", "end", "start", "stretch"],
+              "default": "stretch"
             }
-          }
-        },
-        "distribution": {
-          "type": "string",
-          "description": "Defines the arrangement of children along the main axis (vertically). This corresponds to the CSS 'justify-content' property.",
-          "enum": ["start", "center", "end", "spaceBetween", "spaceAround", "spaceEvenly"]
-        },
-        "alignment": {
-          "type": "string",
-          "description": "Defines the alignment of children along the cross axis (horizontally). This corresponds to the CSS 'align-items' property.",
-          "enum": ["center", "end", "start", "stretch"]
+          },
+          "required": ["component", "children"]
         }
-      },
-      "required": ["children"]
+      ],
+      "unevaluatedProperties": false
     },
     "List": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "children": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "Defines the children. Use 'explicitList' for a fixed set of children, or 'template' to generate children from a data list.",
-          "additionalProperties": false,
           "properties": {
-            "explicitList": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "component": {
+              "const": "List"
             },
-            "template": {
-              "type": "object",
-              "description": "A template for generating a dynamic list of children from a data model list. `componentId` is the component to use as a template, and `dataBinding` is the path to the map of components in the data model. Values in the map will define the list of children.",
-              "additionalProperties": false,
-              "properties": {
-                "componentId": {
-                  "type": "string"
-                },
-                "dataBinding": {
-                  "type": "string"
-                }
-              },
-              "required": ["componentId", "dataBinding"]
+            "children": {
+              "description": "Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.",
+              "$ref": "common_types.json#/$defs/ChildList"
+            },
+            "direction": {
+              "type": "string",
+              "description": "The direction in which the list items are laid out.",
+              "enum": ["vertical", "horizontal"],
+              "default": "vertical"
+            },
+            "align": {
+              "type": "string",
+              "description": "Defines the alignment of children along the cross axis.",
+              "enum": ["start", "center", "end", "stretch"],
+              "default": "stretch"
             }
-          }
-        },
-        "direction": {
-          "type": "string",
-          "description": "The direction in which the list items are laid out.",
-          "enum": ["vertical", "horizontal"]
-        },
-        "alignment": {
-          "type": "string",
-          "description": "Defines the alignment of children along the cross axis.",
-          "enum": ["start", "center", "end", "stretch"]
+          },
+          "required": ["component", "children"]
         }
-      },
-      "required": ["children"]
+      ],
+      "unevaluatedProperties": false
     },
     "Card": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "child": {
-          "type": "string",
-          "description": "The ID of the component to be rendered inside the card."
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Card"
+            },
+            "child": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline."
+            }
+          },
+          "required": ["component", "child"]
         }
-      },
-      "required": ["child"]
+      ],
+      "unevaluatedProperties": false
     },
     "Tabs": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "tabItems": {
-          "type": "array",
-          "description": "An array of objects, where each object defines a tab with a title and a child component.",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "title": {
-                "type": "object",
-                "description": "The tab title. Defines the value as either a literal value or a path to data model value (e.g. '/options/title').",
-                "additionalProperties": false,
-                "properties": {
-                  "literalString": {
-                    "type": "string"
-                  },
-                  "path": {
-                    "type": "string"
-                  }
-                }
-              },
-              "child": {
-                "type": "string"
-              }
-            },
-            "required": ["title", "child"]
-          }
-        }
-      },
-      "required": ["tabItems"]
-    },
-    "Divider": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "axis": {
-          "type": "string",
-          "description": "The orientation of the divider.",
-          "enum": ["horizontal", "vertical"]
-        }
-      }
-    },
-    "Modal": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "entryPointChild": {
-          "type": "string",
-          "description": "The ID of the component that opens the modal when interacted with (e.g., a button)."
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
         },
-        "contentChild": {
-          "type": "string",
-          "description": "The ID of the component to be displayed inside the modal."
-        }
-      },
-      "required": ["entryPointChild", "contentChild"]
-    },
-    "Button": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "child": {
-          "type": "string",
-          "description": "The ID of the component to display in the button, typically a Text component."
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
         },
-        "primary": {
-          "type": "boolean",
-          "description": "Indicates if this button should be styled as the primary action."
-        },
-        "destructive": {
-          "type": "boolean",
-          "description": "Indicates if this button should be styled as a destructive action."
-        },
-        "action": {
+        {
           "type": "object",
-          "description": "The client-side action to be dispatched when the button is clicked. It includes the action's name and an optional context payload.",
-          "additionalProperties": false,
           "properties": {
-            "name": {
-              "type": "string"
+            "component": {
+              "const": "Tabs"
             },
-            "context": {
+            "tabs": {
               "type": "array",
+              "description": "An array of objects, where each object defines a tab with a title and a child component.",
+              "minItems": 1,
               "items": {
                 "type": "object",
-                "additionalProperties": false,
                 "properties": {
-                  "key": {
-                    "type": "string"
+                  "title": {
+                    "description": "The tab title.",
+                    "$ref": "common_types.json#/$defs/DynamicString"
                   },
-                  "value": {
-                    "type": "object",
-                    "description": "Defines the value to be included in the context as either a literal value or a path to a data model value (e.g. '/user/name').",
-                    "additionalProperties": false,
-                    "properties": {
-                      "path": {
-                        "type": "string"
-                      },
-                      "literalString": {
-                        "type": "string"
-                      },
-                      "literalNumber": {
-                        "type": "number"
-                      },
-                      "literalBoolean": {
-                        "type": "boolean"
-                      }
-                    }
+                  "child": {
+                    "$ref": "common_types.json#/$defs/ComponentId",
+                    "description": "The ID of the child component. Do NOT define the component inline."
                   }
                 },
-                "required": ["key", "value"]
+                "required": ["title", "child"],
+                "additionalProperties": false
               }
             }
           },
-          "required": ["name"]
+          "required": ["component", "tabs"]
         }
-      },
-      "required": ["child", "action"]
+      ],
+      "unevaluatedProperties": false
     },
-    "CheckBox": {
+    "Modal": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "label": {
-          "type": "object",
-          "description": "The text to display next to the checkbox. Defines the value as either a literal value or a path to data model ('path', e.g. '/option/label').",
-          "additionalProperties": false,
-          "properties": {
-            "literalString": {
-              "type": "string"
-            },
-            "path": {
-              "type": "string"
-            }
-          }
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
         },
-        "value": {
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "The current state of the checkbox (true for checked, false for unchecked). This can be a literal boolean ('literalBoolean') or a reference to a value in the data model ('path', e.g. '/filter/open').",
-          "additionalProperties": false,
           "properties": {
-            "literalBoolean": {
-              "type": "boolean"
+            "component": {
+              "const": "Modal"
             },
-            "path": {
-              "type": "string"
+            "trigger": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline."
+            },
+            "content": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the component to be displayed inside the modal. Do NOT define the component inline."
             }
-          }
+          },
+          "required": ["component", "trigger", "content"]
         }
-      },
-      "required": ["label", "value"]
+      ],
+      "unevaluatedProperties": false
+    },
+    "Divider": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Divider"
+            },
+            "axis": {
+              "type": "string",
+              "description": "The orientation of the divider.",
+              "enum": ["horizontal", "vertical"],
+              "default": "horizontal"
+            }
+          },
+          "required": ["component"]
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "Button": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "Button"
+            },
+            "child": {
+              "$ref": "common_types.json#/$defs/ComponentId",
+              "description": "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline."
+            },
+            "variant": {
+              "type": "string",
+              "enum": ["default", "primary", "borderless", "destructive"],
+              "default": "default",
+              "description": "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link. 'destructive' indicates a dangerous or irreversible action."
+            },
+            "action": {
+              "$ref": "common_types.json#/$defs/Action"
+            }
+          },
+          "required": ["component", "child", "action"]
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "TextField": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "label": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
           "type": "object",
-          "description": "The text label for the input field. This can be a literal string or a reference to a value in the data model ('path, e.g. '/user/name').",
-          "additionalProperties": false,
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "TextField"
             },
-            "path": {
-              "type": "string"
-            }
-          }
-        },
-        "text": {
-          "type": "object",
-          "description": "The value of the text field. This can be a literal string or a reference to a value in the data model ('path', e.g. '/user/name').",
-          "additionalProperties": false,
-          "properties": {
-            "literalString": {
-              "type": "string"
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the input field."
             },
-            "path": {
-              "type": "string"
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The value of the text field."
+            },
+            "variant": {
+              "type": "string",
+              "description": "The type of input field to display.",
+              "enum": ["longText", "number", "shortText", "obscured"],
+              "default": "shortText"
+            },
+            "validationRegexp": {
+              "type": "string",
+              "description": "A regular expression used for client-side validation of the input."
             }
-          }
-        },
-        "textFieldType": {
-          "type": "string",
-          "description": "The type of input field to display.",
-          "enum": ["date", "longText", "number", "shortText", "obscured"]
-        },
-        "validationRegexp": {
-          "type": "string",
-          "description": "A regular expression used for client-side validation of the input."
+          },
+          "required": ["component", "label"]
         }
-      },
-      "required": ["label"]
+      ],
+      "unevaluatedProperties": false
     },
-    "DateTimeInput": {
+    "CheckBox": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "value": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
           "type": "object",
-          "description": "The selected date and/or time value in ISO 8601 format. This can be a literal string ('literalString') or a reference to a value in the data model ('path', e.g. '/user/dob').",
-          "additionalProperties": false,
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "CheckBox"
             },
-            "path": {
-              "type": "string"
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text to display next to the checkbox."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "The current state of the checkbox (true for checked, false for unchecked)."
             }
-          }
-        },
-        "enableDate": {
-          "type": "boolean",
-          "description": "If true, allows the user to select a date."
-        },
-        "enableTime": {
-          "type": "boolean",
-          "description": "If true, allows the user to select a time."
+          },
+          "required": ["component", "label", "value"]
         }
-      },
-      "required": ["value"]
+      ],
+      "unevaluatedProperties": false
     },
-    "MultipleChoice": {
+    "ChoicePicker": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["selections", "options"],
-      "properties": {
-        "selections": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
           "type": "object",
-          "description": "The currently selected values for the component. This can be a literal array of strings or a path to an array in the data model('path', e.g. '/hotel/options').",
-          "additionalProperties": false,
+          "description": "A component that allows selecting one or more options from a list.",
           "properties": {
-            "literalArray": {
+            "component": {
+              "const": "ChoicePicker"
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The label for the group of options."
+            },
+            "variant": {
+              "type": "string",
+              "description": "A hint for how the choice picker should be displayed and behave.",
+              "enum": ["multipleSelection", "mutuallyExclusive"],
+              "default": "mutuallyExclusive"
+            },
+            "options": {
               "type": "array",
+              "description": "The list of available options to choose from.",
               "items": {
-                "type": "string"
-              }
-            },
-            "path": {
-              "type": "string"
-            }
-          }
-        },
-        "options": {
-          "type": "array",
-          "description": "An array of available options for the user to choose from.",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "label": {
                 "type": "object",
-                "description": "The text to display for this option. This can be a literal string or a reference to a value in the data model (e.g. '/option/label').",
-                "additionalProperties": false,
                 "properties": {
-                  "literalString": {
-                    "type": "string"
+                  "label": {
+                    "description": "The text to display for this option.",
+                    "$ref": "common_types.json#/$defs/DynamicString"
                   },
-                  "path": {
-                    "type": "string"
+                  "value": {
+                    "type": "string",
+                    "description": "The stable value associated with this option."
                   }
-                }
-              },
-              "value": {
-                "type": "string",
-                "description": "The value to be associated with this option when selected."
+                },
+                "required": ["label", "value"],
+                "additionalProperties": false
               }
             },
-            "required": ["label", "value"]
-          }
-        },
-        "maxAllowedSelections": {
-          "type": "integer",
-          "description": "The maximum number of options that the user is allowed to select."
-        },
-        "variant": {
-          "type": "string",
-          "description": "The display style of the component.",
-          "enum": ["checkbox", "chips"]
-        },
-        "filterable": {
-          "type": "boolean",
-          "description": "If true, displays a search input to filter the options."
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicStringList",
+              "description": "The list of currently selected values. This should be bound to a string array in the data model."
+            },
+            "displayStyle": {
+              "type": "string",
+              "description": "The display style of the component.",
+              "enum": ["checkbox", "chips"],
+              "default": "checkbox"
+            },
+            "filterable": {
+              "type": "boolean",
+              "description": "If true, displays a search input to filter the options.",
+              "default": false
+            }
+          },
+          "required": ["component", "options", "value"]
         }
-      }
+      ],
+      "unevaluatedProperties": false
     },
     "Slider": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "value": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
           "type": "object",
-          "description": "The current value of the slider. This can be a literal number ('literalNumber') or a reference to a value in the data model ('path', e.g. '/restaurant/cost').",
-          "additionalProperties": false,
           "properties": {
-            "literalNumber": {
-              "type": "number"
+            "component": {
+              "const": "Slider"
             },
-            "path": {
-              "type": "string"
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The label for the slider."
+            },
+            "min": {
+              "type": "number",
+              "description": "The minimum value of the slider.",
+              "default": 0
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum value of the slider."
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The current value of the slider."
             }
-          }
-        },
-        "minValue": {
-          "type": "number",
-          "description": "The minimum value of the slider."
-        },
-        "maxValue": {
-          "type": "number",
-          "description": "The maximum value of the slider."
+          },
+          "required": ["component", "value", "max"]
         }
-      },
-      "required": ["value"]
+      ],
+      "unevaluatedProperties": false
+    },
+    "DateTimeInput": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "$ref": "common_types.json#/$defs/Checkable"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "DateTimeInput"
+            },
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string."
+            },
+            "enableDate": {
+              "type": "boolean",
+              "description": "If true, allows the user to select a date.",
+              "default": false
+            },
+            "enableTime": {
+              "type": "boolean",
+              "description": "If true, allows the user to select a time.",
+              "default": false
+            },
+            "min": {
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "oneOf": [
+                      {
+                        "format": "date"
+                      },
+                      {
+                        "format": "time"
+                      },
+                      {
+                        "format": "date-time"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "description": "The minimum allowed date/time in ISO 8601 format."
+            },
+            "max": {
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "oneOf": [
+                      {
+                        "format": "date"
+                      },
+                      {
+                        "format": "time"
+                      },
+                      {
+                        "format": "date-time"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "description": "The maximum allowed date/time in ISO 8601 format."
+            },
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the input field."
+            }
+          },
+          "required": ["component", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
     },
     "TagInput": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "label": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "The text label for the tag input field. This can be a literal string or a reference to a value in the data model ('path', e.g. '/form/tagsLabel').",
-          "additionalProperties": false,
+          "description": "A tag input field for adding and removing string tags.",
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "TagInput"
             },
-            "path": {
-              "type": "string"
-            }
-          }
-        },
-        "values": {
-          "type": "object",
-          "description": "The array of tag values. This can be a literal array of strings or a path to an array in the data model ('path', e.g. '/form/tags').",
-          "additionalProperties": false,
-          "properties": {
-            "literalArray": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "label": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The text label for the field."
             },
-            "path": {
-              "type": "string"
-            }
-          }
-        },
-        "placeholder": {
-          "type": "object",
-          "description": "Placeholder text shown when no tags are entered. This can be a literal string or a reference to a value in the data model ('path', e.g. '/form/tagsPlaceholder').",
-          "additionalProperties": false,
-          "properties": {
-            "literalString": {
-              "type": "string"
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicStringList",
+              "description": "The list of current tags. Should be bound to a string array in the data model."
             },
-            "path": {
-              "type": "string"
-            }
-          }
-        },
-        "disabled": {
-          "type": "object",
-          "description": "Whether the tag input is disabled. This can be a literal boolean or a reference to a value in the data model ('path', e.g. '/form/tagsDisabled').",
-          "additionalProperties": false,
-          "properties": {
-            "literalBoolean": {
-              "type": "boolean"
+            "placeholder": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "Placeholder text shown when there are no tags."
             },
-            "path": {
-              "type": "string"
-            }
-          }
-        },
-        "disableTextInput": {
-          "type": "boolean",
-          "description": "If true, hides the text input and only displays the current tags."
-        },
-        "validationRegexp": {
-          "type": "string",
-          "description": "A regular expression used for client-side validation of each tag before it is added. For example, use '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$' for email tags."
-        },
-        "validationErrorMessage": {
-          "type": "object",
-          "description": "Error message shown below the field when a tag fails validationRegexp. This can be a literal string or a reference to a value in the data model ('path', e.g. '/form/emailError').",
-          "additionalProperties": false,
-          "properties": {
-            "literalString": {
-              "type": "string"
+            "disabled": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "If true, the input is disabled."
             },
-            "path": {
-              "type": "string"
+            "disableTextInput": {
+              "type": "boolean",
+              "description": "If true, hides the text input and only displays existing tags."
+            },
+            "validationRegexp": {
+              "type": "string",
+              "description": "A regular expression used to validate each tag before it is added."
+            },
+            "validationErrorMessage": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The error message shown when a tag fails validation."
             }
-          }
+          },
+          "required": ["component", "value"]
         }
-      },
-      "required": ["values"]
+      ],
+      "unevaluatedProperties": false
     },
     "Timeout": {
       "type": "object",
-      "properties": {
-        "targetTimeUtc": {
+      "allOf": [
+        {
+          "$ref": "common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
           "type": "object",
-          "description": "The target time in UTC to count down to. Use an ISO 8601 string (e.g. '2025-02-11T15:30:00.000Z'). This can be a literal string ('literalString') or a reference to a value in the data model ('path', e.g. '/session/expiresAt'). The frontend computes and displays the remaining time until this moment.",
-          "additionalProperties": false,
+          "description": "A countdown timer to a target UTC time.",
           "properties": {
-            "literalString": {
-              "type": "string"
+            "component": {
+              "const": "Timeout"
             },
-            "path": {
-              "type": "string"
+            "targetTimeUtc": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The target time as a UTC ISO 8601 string to count down to."
+            },
+            "variant": {
+              "type": "string",
+              "enum": ["body", "caption", "h3", "h4", "h5"],
+              "description": "A hint for the base text style."
             }
-          }
+          },
+          "required": ["component", "targetTimeUtc"]
         }
-      },
-      "required": ["targetTimeUtc"]
+      ],
+      "unevaluatedProperties": false
     }
   },
-  "styles": {
-    "font": {
-      "type": "string",
-      "description": "The primary font for the UI."
+  "functions": {
+    "required": {
+      "type": "object",
+      "description": "Checks that the value is not null, undefined, or empty.",
+      "properties": {
+        "call": {
+          "const": "required"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "The value to check."
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
     },
-    "primaryColor": {
-      "type": "string",
-      "description": "The primary UI color as a hexadecimal code (e.g., '#00BFFF').",
-      "pattern": "^#[0-9a-fA-F]{6}$"
+    "regex": {
+      "type": "object",
+      "description": "Checks that the value matches a regular expression string.",
+      "properties": {
+        "call": {
+          "const": "regex"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            },
+            "pattern": {
+              "type": "string",
+              "description": "The regex pattern to match against."
+            }
+          },
+          "required": ["value", "pattern"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "length": {
+      "type": "object",
+      "description": "Checks string length constraints.",
+      "properties": {
+        "call": {
+          "const": "length"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            },
+            "min": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The minimum allowed length."
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "The maximum allowed length."
+            }
+          },
+          "required": ["value"],
+          "anyOf": [
+            {
+              "required": ["min"]
+            },
+            {
+              "required": ["max"]
+            }
+          ],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "numeric": {
+      "type": "object",
+      "description": "Checks numeric range constraints.",
+      "properties": {
+        "call": {
+          "const": "numeric"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber"
+            },
+            "min": {
+              "type": "number",
+              "description": "The minimum allowed value."
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum allowed value."
+            }
+          },
+          "required": ["value"],
+          "anyOf": [
+            {
+              "required": ["min"]
+            },
+            {
+              "required": ["max"]
+            }
+          ],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "email": {
+      "type": "object",
+      "description": "Checks that the value is a valid email address.",
+      "properties": {
+        "call": {
+          "const": "email"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatString": {
+      "type": "object",
+      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${expression}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be named (e.g., `${formatDate(value:${/currentDate}, format:'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
+      "properties": {
+        "call": {
+          "const": "formatString"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString"
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatNumber": {
+      "type": "object",
+      "description": "Formats a number with the specified grouping and decimal precision.",
+      "properties": {
+        "call": {
+          "const": "formatNumber"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The number to format."
+            },
+            "decimals": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+            },
+            "grouping": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatCurrency": {
+      "type": "object",
+      "description": "Formats a number as a currency string.",
+      "properties": {
+        "call": {
+          "const": "formatCurrency"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The monetary amount."
+            },
+            "currency": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The ISO 4217 currency code (e.g., 'USD', 'EUR')."
+            },
+            "decimals": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "Optional. The number of decimal places to show. Defaults to 0 or 2 depending on locale."
+            },
+            "grouping": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "Optional. If true, uses locale-specific grouping separators (e.g. '1,000'). If false, returns raw digits (e.g. '1000'). Defaults to true."
+            }
+          },
+          "required": ["currency", "value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "formatDate": {
+      "type": "object",
+      "description": "Formats a timestamp into a string using a pattern.",
+      "properties": {
+        "call": {
+          "const": "formatDate"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicValue",
+              "description": "The date to format."
+            },
+            "format": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "A Unicode TR35 date pattern string.\n\nToken Reference:\n- Year: 'yy' (26), 'yyyy' (2026)\n- Month: 'M' (1), 'MM' (01), 'MMM' (Jan), 'MMMM' (January)\n- Day: 'd' (1), 'dd' (01), 'E' (Tue), 'EEEE' (Tuesday)\n- Hour (12h): 'h' (1-12), 'hh' (01-12) - requires 'a' for AM/PM\n- Hour (24h): 'H' (0-23), 'HH' (00-23) - Military Time\n- Minute: 'mm' (00-59)\n- Second: 'ss' (00-59)\n- Period: 'a' (AM/PM)\n\nExamples:\n- 'MMM dd, yyyy' -> 'Jan 16, 2026'\n- 'HH:mm' -> '14:30' (Military)\n- 'h:mm a' -> '2:30 PM'\n- 'EEEE, d MMMM' -> 'Friday, 16 January'"
+            }
+          },
+          "required": ["format", "value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "pluralize": {
+      "type": "object",
+      "description": "Returns a localized string based on the Common Locale Data Repository (CLDR) plural category of the count (zero, one, two, few, many, other). Requires an 'other' fallback. For English, just use 'one' and 'other'.",
+      "properties": {
+        "call": {
+          "const": "pluralize"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "The numeric value used to determine the plural category."
+            },
+            "zero": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'zero' category (e.g., 0 items)."
+            },
+            "one": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'one' category (e.g., 1 item)."
+            },
+            "two": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'two' category (used in Arabic, Welsh, etc.)."
+            },
+            "few": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'few' category (e.g., small groups in Slavic languages)."
+            },
+            "many": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "String for the 'many' category (e.g., large groups in various languages)."
+            },
+            "other": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The default/fallback string (used for general plural cases)."
+            }
+          },
+          "required": ["value", "other"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "string"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "openUrl": {
+      "type": "object",
+      "description": "Opens the specified URL in a browser or handler. This function has no return value.",
+      "properties": {
+        "call": {
+          "const": "openUrl"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URL to open."
+            }
+          },
+          "required": ["url"],
+          "additionalProperties": false
+        },
+        "returnType": {
+          "const": "void"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "and": {
+      "type": "object",
+      "description": "Performs a logical AND operation on a list of boolean values.",
+      "properties": {
+        "call": {
+          "const": "and"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "values": {
+              "type": "array",
+              "description": "The list of boolean values to evaluate.",
+              "items": {
+                "$ref": "common_types.json#/$defs/DynamicBoolean"
+              },
+              "minItems": 2
+            }
+          },
+          "required": ["values"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "or": {
+      "type": "object",
+      "description": "Performs a logical OR operation on a list of boolean values.",
+      "properties": {
+        "call": {
+          "const": "or"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "values": {
+              "type": "array",
+              "description": "The list of boolean values to evaluate.",
+              "items": {
+                "$ref": "common_types.json#/$defs/DynamicBoolean"
+              },
+              "minItems": 2
+            }
+          },
+          "required": ["values"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "not": {
+      "type": "object",
+      "description": "Performs a logical NOT operation on a boolean value.",
+      "properties": {
+        "call": {
+          "const": "not"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicBoolean",
+              "description": "The boolean value to negate."
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": {
+          "const": "boolean"
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    }
+  },
+  "$defs": {
+    "CatalogComponentCommon": {
+      "type": "object",
+      "properties": {
+        "weight": {
+          "type": "number",
+          "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+        }
+      }
+    },
+    "theme": {
+      "type": "object",
+      "properties": {
+        "primaryColor": {
+          "type": "string",
+          "description": "The primary brand color used for highlights (e.g., primary buttons, active borders). Renderers may generate variants of this color for different contexts. Format: Hexadecimal code (e.g., '#00BFFF').",
+          "pattern": "^#[0-9a-fA-F]{6}$"
+        },
+        "iconUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "A URL for an image that identifies the agent or tool associated with the surface."
+        },
+        "agentDisplayName": {
+          "type": "string",
+          "description": "Text to be displayed next to the surface to identify the agent or tool that created it."
+        }
+      },
+      "additionalProperties": true
+    },
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/AudioPlayer"
+        },
+        {
+          "$ref": "#/components/Button"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/CheckBox"
+        },
+        {
+          "$ref": "#/components/ChoicePicker"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/DateTimeInput"
+        },
+        {
+          "$ref": "#/components/Divider"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/Image"
+        },
+        {
+          "$ref": "#/components/List"
+        },
+        {
+          "$ref": "#/components/Modal"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Slider"
+        },
+        {
+          "$ref": "#/components/Tabs"
+        },
+        {
+          "$ref": "#/components/TagInput"
+        },
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/TextField"
+        },
+        {
+          "$ref": "#/components/Timeout"
+        },
+        {
+          "$ref": "#/components/Video"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "component"
+      }
+    },
+    "anyFunction": {
+      "oneOf": [
+        {
+          "$ref": "#/functions/required"
+        },
+        {
+          "$ref": "#/functions/regex"
+        },
+        {
+          "$ref": "#/functions/length"
+        },
+        {
+          "$ref": "#/functions/numeric"
+        },
+        {
+          "$ref": "#/functions/email"
+        },
+        {
+          "$ref": "#/functions/formatString"
+        },
+        {
+          "$ref": "#/functions/formatNumber"
+        },
+        {
+          "$ref": "#/functions/formatCurrency"
+        },
+        {
+          "$ref": "#/functions/formatDate"
+        },
+        {
+          "$ref": "#/functions/pluralize"
+        },
+        {
+          "$ref": "#/functions/openUrl"
+        },
+        {
+          "$ref": "#/functions/and"
+        },
+        {
+          "$ref": "#/functions/or"
+        },
+        {
+          "$ref": "#/functions/not"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `glchat-a2ui-react-renderer` to `^0.3.0` and `next` to `^16.2.10`
- Migrates A2UI protocol from v0.2 to v0.9
- Renames `AllSurfacesRenderer` → `SurfaceRenderer`
- Adds `A2UIMessage` TypeScript types
- Updates all 12 sample data files to new component catalog
- Removes `DestructiveButton` and `ButtonAsLink` (replaced by `Button` with variants)
- Adds `createSurface` and `event` wrapper for actions
- Renames properties: `usageHint` → `variant`, `distribution` → `justify`
- Adds new `json/a2ui-sample-messages.json` sample file

## Demo
https://github.com/user-attachments/assets/9ce18180-9596-46ff-8133-462405792f13

