### PR TITLE
fix(how-to-guide): e2e-pipeline replace removed BasicVectorRetriever import

### DIFF
--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/012_rag_with_dynamic_models/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/012_rag_with_dynamic_models/pipeline.py
@@ -10,7 +10,7 @@ from gllm_inference.em_invoker.openai_em_invoker import OpenAIEMInvoker
 from gllm_generation.response_synthesizer import ResponseSynthesizer
 from gllm_pipeline.pipeline import Pipeline
 from gllm_pipeline.steps import step
-from gllm_retrieval.retriever.vector_retriever import BasicVectorRetriever
+from gllm_retrieval.retriever.vector_retriever_v2 import VectorRetriever
 
 
 load_dotenv()
@@ -34,7 +34,7 @@ data_store = ChromaVectorDataStore(
     persist_directory="data",
     embedding=em_invoker,
 )
-retriever = BasicVectorRetriever(data_store)
+retriever = VectorRetriever(data_store)
 
 
 def build_pipeline(model_id: str) -> Pipeline:


### PR DESCRIPTION
## Summary
- `BasicVectorRetriever` no longer exists in `gllm_retrieval.retriever.vector_retriever` on current gl-sdk main (module was restructured).
- Swaps to the current equivalent, `VectorRetriever` from `gllm_retrieval.retriever.vector_retriever_v2`, which takes the same `(data_store)` constructor arg — no other changes needed.
- Confirmed against the example's pinned `gllm-retrieval==0.6.4`: `uv sync` installs cleanly and the import/constructor signature resolve as expected.

Follow-up from `STALE_COOKBOOK_NOTES.md` — this PR only fixes the one confirmed break; the broader version-pin bump across all 13 examples is tracked separately.

## Test plan
- [x] `uv sync` succeeds against pinned `gllm-retrieval==0.6.4`
- [x] `VectorRetriever` import resolves and `__init__` signature matches `(self, data_store)`
- [x] `py_compile` passes on the edited file
- [ ] Full end-to-end run (needs API keys / populated vector store) — not run, per stale notes' guidance to confirm API spend with cookbook owner first