### PR TITLE
chore: remove Authors docstring entries from how-to-guides and tutorials

### DIFF
--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/001_your_first_rag_pipeline/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/001_your_first_rag_pipeline/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/001_your_first_rag_pipeline/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/001_your_first_rag_pipeline/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a simple RAG pipeline.
 
-Authors:
-    Henry Wicaksono (henry.wicaksono@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/your-first-rag-pipeline
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/002_dynamic_step/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/002_dynamic_step/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/002_dynamic_step/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/002_dynamic_step/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a simple RAG pipeline with dynamic step.
 
-Authors:
-    Delfia N. A. Putri (delfia.n.a.putri@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/dynamic-step
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/003_implement_semantic_routing/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/003_implement_semantic_routing/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/003_implement_semantic_routing/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/003_implement_semantic_routing/pipeline.py
@@ -1,7 +1,4 @@
 """Example script to build and run a simple RAG pipeline with semantic routing.
-Authors:
-    Delfia N. A. Putri (delfia.n.a.putri@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/implement-semantic-routing
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/004_adding_document_references/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/004_adding_document_references/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/004_adding_document_references/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/004_adding_document_references/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a RAG pipeline with document references.
 
-Authors:
-    Delfia N.A Putri (delfia.n.a.putri@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/adding-document-references
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/005_simple_guardrail/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/005_simple_guardrail/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/005_simple_guardrail/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/005_simple_guardrail/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a RAG pipeline with simple guardrail.
 
-Authors:
-    Delfia N. A. Putri (delfia.n.a.putri@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/simple-guardrail
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/006_query_transformation/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/006_query_transformation/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/006_query_transformation/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/006_query_transformation/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a RAG pipeline with query transformation.
 
-Authors:
-    Delfia N. A. Putri (delfia.n.a.putri@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/query-transformation
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/007_multimodal_input_handling/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/007_multimodal_input_handling/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-    
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/007_multimodal_input_handling/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/007_multimodal_input_handling/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a RAG pipeline with multimodal input handling.
 
-Authors:
-    Delfia N.A Putri (delfia.n.a.putri@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/multimodal-input-handling
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/008_caching/indexer.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/008_caching/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a CSV file into a vector store.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/008_caching/pipeline.py
+++ b/gen-ai/how-to-guides/build_end_to_end_rag_pipeline/008_caching/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build a pipeline with caching enabled.
 
-Authors:
-    Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/build-end-to-end-rag-pipeline/caching
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/001_simple_image_rag_pipeline/indexer.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/001_simple_image_rag_pipeline/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index images extracted from a PDF into a vector store.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/image-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/001_simple_image_rag_pipeline/pipeline.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/001_simple_image_rag_pipeline/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a simple image RAG pipeline.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/image-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/002_contextual_image_captioning/indexer.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/002_contextual_image_captioning/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index images with contextual captions extracted from a PDF.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/image-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/002_contextual_image_captioning/pipeline.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/002_contextual_image_captioning/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run an image search RAG pipeline with contextual captions.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/image-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/003_intelligent_image_routing/indexer.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/003_intelligent_image_routing/indexer.py
@@ -1,9 +1,6 @@
 """Example script to index a mixed set of images (photos + diagrams) using smart routing
 with contextual captions enriched by surrounding section text.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/smart-image-routing
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/003_intelligent_image_routing/pipeline.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/003_intelligent_image_routing/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a smart image routing RAG pipeline.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/smart-image-routing
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/004_image_input_handling/indexer.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/004_image_input_handling/indexer.py
@@ -1,9 +1,6 @@
 """Example script to index a mixed set of images (photos + diagrams) using smart routing
 with contextual captions enriched by surrounding section text.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/smart-image-routing
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/004_image_input_handling/pipeline.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/004_image_input_handling/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to search by image in a multimodal RAG pipeline.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/search-by-image
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/005_simple_video_rag_pipeline/indexer.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/005_simple_video_rag_pipeline/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a YouTube video by transcript segments into a vector store.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/video-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/005_simple_video_rag_pipeline/pipeline.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/005_simple_video_rag_pipeline/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a video search RAG pipeline with timestamped retrieval.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/video-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/006_long_video_rag_pipeline/indexer.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/006_long_video_rag_pipeline/indexer.py
@@ -1,8 +1,5 @@
 """Example script to index a YouTube video by transcript segments into a vector store.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/video-search-pipeline
 """

--- a/gen-ai/how-to-guides/build_multimodal_rag_pipeline/006_long_video_rag_pipeline/pipeline.py
+++ b/gen-ai/how-to-guides/build_multimodal_rag_pipeline/006_long_video_rag_pipeline/pipeline.py
@@ -1,8 +1,5 @@
 """Example script to build and run a video search RAG pipeline with timestamped retrieval.
 
-Authors:
-    Nico Samuelson Tjandra (nico.s.tjandra@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/guides/build-multimodal-rag-pipeline/video-search-pipeline
 """

--- a/gen-ai/how-to-guides/index_your_data/indexing.py
+++ b/gen-ai/how-to-guides/index_your_data/indexing.py
@@ -1,8 +1,5 @@
 """An example of indexing data into a vector store.
 
-Authors:
-    - Kadek Denaya (kadek.d.r.diana@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/how-to-guides/index-your-data-with-vector-data-store
 """

--- a/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_binary_classification/evaluate_suites_binary_classification.py
+++ b/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_binary_classification/evaluate_suites_binary_classification.py
@@ -3,9 +3,6 @@
 Loads a dataset from a local JSON file with a ``category`` field, dynamically
 builds one EvalSuite per category, and computes TPR/TNR/accuracy aggregators.
 
-Authors:
-    - Kalvin (kalvinsupriadi3@gmail.com)
-
 References:
     [1] None
 """

--- a/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_standard/evaluate_suites_standard.py
+++ b/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_standard/evaluate_suites_standard.py
@@ -4,9 +4,6 @@ This example demonstrates two suites with test cases loaded from local data file
 - qa: Simple Q&A evaluation (generation evaluator)
 - agent: Agent tool-use evaluation (includes tools_called/expected_tools)
 
-Authors:
-    - Kalvin (kalvinsupriadi3@gmail.com)
-
 References:
     [1] None
 """

--- a/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_with_google_sheets_experiment_tracker/evaluate_suites_google_sheets.py
+++ b/gen-ai/tutorials/evaluations/evaluate_suites/evaluate_suites_with_google_sheets_experiment_tracker/evaluate_suites_google_sheets.py
@@ -9,9 +9,6 @@ This is useful for:
 - Running different evaluation strategies on different data partitions
 - Comparing results across multiple evaluation configurations
 
-Authors:
-    Mikhael Chris (mikhael.chris@gdplabs.id)
-
 References:
     NONE
 """

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval.py
@@ -4,9 +4,6 @@ The dataset includes expected_tools, so DeepEvalToolCorrectnessMetric is include
 in the initial evaluation alongside the default generation metrics. This gives an
 early signal on agent routing correctness before any calibration is applied.
 
-Authors:
-    Daniel Adi (daniel.adi@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/tutorials/evaluation/evals-lifecycle
 """

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval_calibrated.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/agent_qna_evaluations/eval_calibrated.py
@@ -13,9 +13,6 @@ Calibration for multi-value enumeration queries (Cases 1 and 3):
 Case 2 (single-value lookup) keeps the default evaluator. Single-fact answers
 have a stable, single-source reference where completeness is appropriate.
 
-Authors:
-    Daniel Adi (daniel.adi@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/tutorials/evaluation/evals-lifecycle
 """

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval.py
@@ -1,8 +1,5 @@
 """Example script to evaluate a RAG pipeline using a mock pipeline.
 
-Authors:
-    Daniel Adi (daniel.adi@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/tutorials/evaluation/evals-lifecycle
 """

--- a/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval_calibrated.py
+++ b/gen-ai/tutorials/evaluations/tutorials_by_task/rag_chatbot_evals/eval_calibrated.py
@@ -9,9 +9,6 @@ Calibration for the browse query (Case 1):
 Cases 2 and 3 (precise queries) keep the default evaluator. Single-fact answers
 have a stable reference where completeness at 1.0 is correct.
 
-Authors:
-    Daniel Adi (daniel.adi@gdplabs.id)
-
 References:
     [1] https://gdplabs.gitbook.io/sdk/gen-ai-sdk/tutorials/evaluation/evals-lifecycle
 """

--- a/gen-ai/tutorials/experiment_tracker/csv_experiment_tracker/example_experiment_tracker.py
+++ b/gen-ai/tutorials/experiment_tracker/csv_experiment_tracker/example_experiment_tracker.py
@@ -1,8 +1,5 @@
 """Example of using the CSVExperimentTracker with the evaluate function.
 
-Authors:
-    Apri Dwi Rachmadi (apri.d.rachmadi@gdplabs.id)
-
 References:
     NONE
 """

--- a/gen-ai/tutorials/experiment_tracker/csv_experiment_tracker_single_log/example_experiment_tracker_single_log.py
+++ b/gen-ai/tutorials/experiment_tracker/csv_experiment_tracker_single_log/example_experiment_tracker_single_log.py
@@ -1,8 +1,5 @@
 """Example of using the CSVExperimentTracker with a single manual log.
 
-Authors:
-    Apri Dwi Rachmadi (apri.d.rachmadi@gdplabs.id)
-
 References:
     NONE
 """

--- a/gen-ai/tutorials/experiment_tracker/langfuse_experiment_tracker/example_langfuse_experiment_tracker.py
+++ b/gen-ai/tutorials/experiment_tracker/langfuse_experiment_tracker/example_langfuse_experiment_tracker.py
@@ -1,8 +1,5 @@
 """Example of using the Langfuse Experiment Tracker.
 
-Authors:
-    Christina Alexandra (christina.alexandra@gdplabs.id)
-
 References:
     NONE
 """

--- a/gen-ai/tutorials/experiment_tracker/langfuse_refresh_or_export/example_refresh_or_export.py
+++ b/gen-ai/tutorials/experiment_tracker/langfuse_refresh_or_export/example_refresh_or_export.py
@@ -1,8 +1,5 @@
 """Example of using the LangfuseExperimentTracker to refresh or export langfuse session-level score.
 
-Authors:
-    Christina Alexandra (christina.alexandra@gdplabs.id)
-
 References:
     NONE
 """


### PR DESCRIPTION
## Summary
- Removes the `Authors:` docstring field from all example scripts under `gen-ai/how-to-guides` and `gen-ai/tutorials`.
- 40 files changed, 120 deletions. No logic, imports, or other content touched.
- Scope: only module-level docstrings in `.py` example scripts under the two requested directories.

## Scope notes
- `gl-aip/` has no `Authors:` entries, so nothing changed there.
- Three top-level `deep-research/*.py` files also contain an `Authors:` field but live outside the how-to-guides/tutorials directories, so they were intentionally left untouched. Let me know if you want those removed too.

## Test plan
- [x] `grep -rn 'Authors:' --include='*.py' gen-ai/how-to-guides gen-ai/tutorials` returns no matches
- [x] Docstrings remain well-formed (no double blank lines; `References:` section preserved)